### PR TITLE
✨ feat: 주문 마감 시간 등록, 수정

### DIFF
--- a/src/main/java/com/x1/frans/order/command/application/controller/StoreOrderDeadlineController.java
+++ b/src/main/java/com/x1/frans/order/command/application/controller/StoreOrderDeadlineController.java
@@ -1,0 +1,28 @@
+package com.x1.frans.order.command.application.controller;
+
+import com.x1.frans.order.command.application.service.StoreOrderDeadlineService;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/deadline")
+@RequiredArgsConstructor
+public class StoreOrderDeadlineController {
+
+    private final StoreOrderDeadlineService storeOrderDeadlineService;
+
+    @PostMapping
+    public ResponseEntity<String> createOrUpdateDeadline(
+            @RequestParam("time")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.TIME) LocalTime deadlineTime) {
+        boolean isCreated = storeOrderDeadlineService.createOrUpdateDeadline(deadlineTime);
+        String message = isCreated ? "주문 마감 시간이 등록되었습니다." : "주문 마감 시간이 변경되었습니다.";
+        return ResponseEntity.status(isCreated ? 201 : 200).body(message);
+    }
+}

--- a/src/main/java/com/x1/frans/order/command/application/service/StoreOrderDeadlineService.java
+++ b/src/main/java/com/x1/frans/order/command/application/service/StoreOrderDeadlineService.java
@@ -1,0 +1,7 @@
+package com.x1.frans.order.command.application.service;
+
+import java.time.LocalTime;
+
+public interface StoreOrderDeadlineService {
+    boolean createOrUpdateDeadline(LocalTime deadlineTime);
+}

--- a/src/main/java/com/x1/frans/order/command/application/service/StoreOrderDeadlineServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/command/application/service/StoreOrderDeadlineServiceImpl.java
@@ -1,0 +1,30 @@
+package com.x1.frans.order.command.application.service;
+
+import com.x1.frans.order.command.domain.aggregate.StoreOrderDeadline;
+import com.x1.frans.order.command.domain.repository.StoreOrderDeadlineRepository;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StoreOrderDeadlineServiceImpl implements StoreOrderDeadlineService {
+
+    private final StoreOrderDeadlineRepository storeOrderDeadlineRepository;
+
+    @Override
+    @Transactional
+    public boolean createOrUpdateDeadline(LocalTime deadlineTime) {
+        StoreOrderDeadline deadline = storeOrderDeadlineRepository.findById(1).orElse(null);
+
+        if (deadline == null) {
+            StoreOrderDeadline newDeadline = new StoreOrderDeadline(deadlineTime);
+            storeOrderDeadlineRepository.save(newDeadline);
+            return true;
+        } else {
+            deadline.updateDeadlineTime(deadlineTime);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/x1/frans/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/x1/frans/order/command/domain/aggregate/Order.java
@@ -1,0 +1,58 @@
+package com.x1.frans.order.command.domain.aggregate;
+
+import com.x1.frans.franchise.command.aggregate.FranchiseEntity;
+import com.x1.frans.user.command.aggregate.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "code", nullable = false, unique = true)
+    private String code;
+
+    @Column(name = "status", nullable = false)
+    private String status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "total_amount", nullable = false)
+    private Integer totalAmount;
+
+    @Column(name = "rejected_reason")
+    private String rejectedReason;
+
+    @Column(name = "rejected_at")
+    private LocalDateTime rejectedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "franchise_id", nullable = false)
+    private FranchiseEntity franchise;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+}

--- a/src/main/java/com/x1/frans/order/command/domain/aggregate/StoreOrderDeadline.java
+++ b/src/main/java/com/x1/frans/order/command/domain/aggregate/StoreOrderDeadline.java
@@ -1,0 +1,36 @@
+package com.x1.frans.order.command.domain.aggregate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "store_order_deadline")
+public class StoreOrderDeadline {
+
+    /**
+     * 단 하나의 레코드만 존재 (id = 1). 주문 마감 시간을 관리하기 위한 단일 설정값 용도.
+     */
+    @Id
+    private Integer id;
+
+    @Column(name = "order_deadline_at", nullable = false)
+    private LocalTime orderDeadlineAt;
+
+    public StoreOrderDeadline(LocalTime orderDeadlineAt) {
+        this.id = 1;
+        this.orderDeadlineAt = orderDeadlineAt;
+    }
+
+    public void updateDeadlineTime(LocalTime newDeadlineTime) {
+        this.orderDeadlineAt = newDeadlineTime;
+    }
+}

--- a/src/main/java/com/x1/frans/order/command/domain/repository/OrderCommandRepository.java
+++ b/src/main/java/com/x1/frans/order/command/domain/repository/OrderCommandRepository.java
@@ -1,0 +1,9 @@
+package com.x1.frans.order.command.domain.repository;
+
+import com.x1.frans.order.command.domain.aggregate.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderCommandRepository extends JpaRepository<Order, Integer> {
+}

--- a/src/main/java/com/x1/frans/order/command/domain/repository/StoreOrderDeadlineRepository.java
+++ b/src/main/java/com/x1/frans/order/command/domain/repository/StoreOrderDeadlineRepository.java
@@ -1,0 +1,9 @@
+package com.x1.frans.order.command.domain.repository;
+
+import com.x1.frans.order.command.domain.aggregate.StoreOrderDeadline;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreOrderDeadlineRepository extends JpaRepository<StoreOrderDeadline, Integer> {
+}


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #5 

## ✅ 작업 사항

- 주문 마감 시간이 등록되어 있지 않다면 -> 마감 시간 등록
- 주문 마감 시간이 등록되어 있다면 -> 마감 시간 수정

<br>

- store_order_deadline에 여러 레코드가 쌓이는 것은 불필요하다고 생각하여, 단 하나의 레코드만 존재하게 구현하였습니다.
이유 : 본사가 모든 가맹점에 동일한 마감 시간을 적용한다면, 시간은 하나만 유지되는 게 맞다고 판단.

## 📸 스크린샷 (선택)
<img width="686" alt="image" src="https://github.com/user-attachments/assets/9cb69eae-ea79-4adb-99b4-4f3e53889e3b" />
<img width="691" alt="image" src="https://github.com/user-attachments/assets/1516acf7-19e6-4fed-b128-24b516839b03" />


## 👩‍💻 공유 포인트 및 논의 사항
예외처리는 추후 추가할 예정입니다.
