### PR TITLE
✨ feat: 본사용 주문 목록 조회 및 필터 기능 구현

### DIFF
--- a/src/main/java/com/x1/frans/config/SwaggerConfig.java
+++ b/src/main/java/com/x1/frans/config/SwaggerConfig.java
@@ -19,7 +19,7 @@ public class SwaggerConfig {
     public GroupedOpenApi orderApi() {
         return GroupedOpenApi.builder()
                 .group("주문")
-                .pathsToMatch("/api/orders/**")
+                .pathsToMatch("/api/hq/orders/**")
                 .build();
     }
 }

--- a/src/main/java/com/x1/frans/config/SwaggerConfig.java
+++ b/src/main/java/com/x1/frans/config/SwaggerConfig.java
@@ -19,7 +19,7 @@ public class SwaggerConfig {
     public GroupedOpenApi orderApi() {
         return GroupedOpenApi.builder()
                 .group("주문")
-                .pathsToMatch("/api/order/**")
+                .pathsToMatch("/api/orders/**")
                 .build();
     }
 }

--- a/src/main/java/com/x1/frans/order/command/application/controller/StoreOrderDeadlineController.java
+++ b/src/main/java/com/x1/frans/order/command/application/controller/StoreOrderDeadlineController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/order/deadline")
+@RequestMapping("/api/orders/deadline")
 @Tag(name = "📝 주문", description = "orders")
 public class StoreOrderDeadlineController {
 

--- a/src/main/java/com/x1/frans/order/command/application/controller/StoreOrderDeadlineController.java
+++ b/src/main/java/com/x1/frans/order/command/application/controller/StoreOrderDeadlineController.java
@@ -5,8 +5,6 @@ import com.x1.frans.order.command.application.service.StoreOrderDeadlineService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.LocalTime;
-import java.time.format.DateTimeParseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,9 +12,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/orders/deadline")
+@RequestMapping("/api/hq/orders/deadline")
 @Tag(name = "📝 주문", description = "orders")
 public class StoreOrderDeadlineController {
 

--- a/src/main/java/com/x1/frans/order/query/controller/OrderQueryController.java
+++ b/src/main/java/com/x1/frans/order/query/controller/OrderQueryController.java
@@ -1,0 +1,36 @@
+package com.x1.frans.order.query.controller;
+
+import com.x1.frans.order.query.dto.OrderSearchConditionDto;
+import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
+import com.x1.frans.order.query.service.OrderQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/hq/orders")
+@RequiredArgsConstructor
+public class OrderQueryController {
+    private final OrderQueryService orderQueryService;
+
+    @GetMapping
+    public OrderSearchPageResponseDto searchOrdersPaged(
+            @RequestParam(required = false) Long franchiseId,
+            @RequestParam(required = false) String filterType,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        OrderSearchConditionDto condition = OrderSearchConditionDto.builder()
+                .franchiseId(franchiseId)
+                .filterType(filterType)
+                .keyword(keyword)
+                .page(page)
+                .size(size)
+                .build();
+
+        return orderQueryService.searchOrders(condition);
+    }
+}

--- a/src/main/java/com/x1/frans/order/query/dao/OrderQueryMapper.java
+++ b/src/main/java/com/x1/frans/order/query/dao/OrderQueryMapper.java
@@ -1,0 +1,15 @@
+package com.x1.frans.order.query.dao;
+
+import com.x1.frans.order.query.dto.OrderSearchConditionDto;
+import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface OrderQueryMapper {
+    // 목록 조회 (LIMIT, OFFSET 적용)
+    List<OrderSummaryResponseDto> searchOrders(OrderSearchConditionDto condition);
+
+    // 전체 개수 조회 (페이징 계산용)
+    int countOrders(OrderSearchConditionDto condition);
+}

--- a/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
@@ -1,0 +1,17 @@
+package com.x1.frans.order.query.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class OrderSearchConditionDto {
+    private Long franchiseId;
+    private String filterType;
+    private String keyword;
+    private int page;
+    private int size;           // 한 페이지당 목록 개수
+    private int offset;         // size * (page -1)
+}

--- a/src/main/java/com/x1/frans/order/query/dto/OrderSearchPageResponseDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/OrderSearchPageResponseDto.java
@@ -1,0 +1,17 @@
+package com.x1.frans.order.query.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderSearchPageResponseDto {
+    private List<OrderSummaryResponseDto> content;
+    private int totalCount;
+    private int page;
+    private int size;
+    private int totalPages;
+    private boolean hasNext;
+    private boolean hasPrevious;
+}

--- a/src/main/java/com/x1/frans/order/query/dto/OrderSummaryResponseDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/OrderSummaryResponseDto.java
@@ -1,0 +1,17 @@
+package com.x1.frans.order.query.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderSummaryResponseDto {
+    private Long orderId;
+    private String orderCode;
+    private String productSummary;
+    private String status;
+    private LocalDateTime createdAt;
+    private int totalAmount;
+    private String franchiseName;
+}

--- a/src/main/java/com/x1/frans/order/query/service/OrderQueryService.java
+++ b/src/main/java/com/x1/frans/order/query/service/OrderQueryService.java
@@ -1,0 +1,8 @@
+package com.x1.frans.order.query.service;
+
+import com.x1.frans.order.query.dto.OrderSearchConditionDto;
+import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
+
+public interface OrderQueryService {
+    OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition);
+}

--- a/src/main/java/com/x1/frans/order/query/service/OrderQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/query/service/OrderQueryServiceImpl.java
@@ -1,0 +1,39 @@
+package com.x1.frans.order.query.service;
+
+import com.x1.frans.order.query.dao.OrderQueryMapper;
+import com.x1.frans.order.query.dto.OrderSearchConditionDto;
+import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
+import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderQueryServiceImpl implements OrderQueryService {
+
+    private final OrderQueryMapper orderQueryMapper;
+
+    @Override
+    public OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition) {
+
+        // 페이지 오프셋 계산
+        int offset = (condition.getPage() - 1) * condition.getSize();
+        condition.setOffset(offset);
+
+        // 주문 목록 및 총 개수 조회
+        List<OrderSummaryResponseDto> content = orderQueryMapper.searchOrders(condition);
+        int totalCount = orderQueryMapper.countOrders(condition);
+        int totalPages = (int) Math.ceil((double) totalCount / condition.getSize());
+
+        return OrderSearchPageResponseDto.builder()
+                .content(content)
+                .totalCount(totalCount)
+                .page(condition.getPage())
+                .size(condition.getSize())
+                .totalPages(totalPages)
+                .hasNext(condition.getPage() < totalPages)
+                .hasPrevious(condition.getPage() > 1)
+                .build();
+    }
+}

--- a/src/main/java/com/x1/frans/security/config/SecurityConfig.java
+++ b/src/main/java/com/x1/frans/security/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import com.x1.frans.security.handler.CustomAuthenticationFailureHandler;
 import com.x1.frans.security.util.JwtUtil;
 import com.x1.frans.user.query.service.UserQueryService;
 import jakarta.servlet.Filter;
+import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,8 +22,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-
-import java.util.Collections;
 
 @Configuration
 public class SecurityConfig {
@@ -69,14 +68,27 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(authorize ->
 
-                // TODO: 개발용 설정. 배포 시 변경 필요
-                authorize
-                        .requestMatchers("/**").permitAll())
-//                        .requestMatchers("/auth/reissue").permitAll()
-//                        .requestMatchers("/**").hasRole("ADMIN"))
-                .authenticationManager(authenticationManager())
-            .sessionManagement(session ->
-                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                        // TODO: 개발용 설정. 배포 시 변경 필요
+                        authorize
+                                .requestMatchers("/**").permitAll()
+//                              .requestMatchers("/auth/reissue").permitAll()
+//                              .requestMatchers("/**").hasRole("ADMIN"))
+
+                                // 본사 전용
+                                .requestMatchers("/api/hq/**").hasRole("HQ")
+
+                                // 가맹점 전용
+                                .requestMatchers("/api/franchise/**").hasRole("FRANCHISE")
+
+                                // 공급사 전용 예시
+                                .requestMatchers("/api/supplier/**").hasRole("SUPPLIER")
+                
+        );
+
+        http.authenticationManager(authenticationManager());
+
+        http.sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http.addFilterBefore(new JwtAuthenticationFilter(jwtUtil, userQueryService, objectMapper),
                 AuthenticationFilter.class);

--- a/src/main/java/com/x1/frans/supplier/query/controller/SupplierQueryController.java
+++ b/src/main/java/com/x1/frans/supplier/query/controller/SupplierQueryController.java
@@ -1,20 +1,18 @@
 package com.x1.frans.supplier.query.controller;
 
-import com.x1.frans.supplier.query.dto.SupplierListDTO;
 import com.x1.frans.supplier.query.dto.SupplierDetailDTO;
+import com.x1.frans.supplier.query.dto.SupplierListDTO;
 import com.x1.frans.supplier.query.service.SupplierQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import com.x1.frans.supplier.command.aggregate.SupplierEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @Tag(name = "공급처", description = "공급처 관련 API")
 @RestController
@@ -38,6 +36,7 @@ public class SupplierQueryController {
         return ResponseEntity.ok(list);
 
     }
+
     @Operation(summary = "공급처 상세 조회", description = "공급처 상세 조회합니다.")
     @GetMapping("/detail/{supplierId}")
     public ResponseEntity<SupplierDetailDTO> detail(@PathVariable("supplierId") int supplierId) {

--- a/src/main/resources/com/x1/frans/order/query/dao/OrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/OrderQueryMapper.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.x1.frans.order.query.dao.OrderQueryMapper">
+
+    <resultMap id="OrderSummaryMap" type="com.x1.frans.order.query.dto.OrderSummaryResponseDto">
+        <id property="orderId" column="order_id"/>
+        <result property="orderCode" column="order_code"/>
+        <result property="productSummary" column="product_summary"/>
+        <result property="status" column="status"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="totalAmount" column="total_amount"/>
+        <result property="franchiseName" column="franchise_name"/>
+    </resultMap>
+
+    <!-- 주문 목록 조회 (검색, 페이징 포함) -->
+    <select id="searchOrders" resultMap="OrderSummaryMap"
+            parameterType="com.x1.frans.order.query.dto.OrderSearchConditionDto">
+        SELECT
+        o.id AS order_id
+        , o.code AS order_code
+        , CONCAT(p.name, ' 외 ', COUNT(*) - 1, '건') AS product_summary
+        , o.status
+        , o.created_at
+        , o.total_amount
+        , f.name AS franchise_name
+        FROM orders o
+        JOIN franchise f ON o.franchise_id = f.id
+        JOIN product_order po ON o.id = po.order_id
+        JOIN product p ON po.product_id = p.id
+        <where>
+            <if test="franchiseId != null">
+                o.franchise_id = #{franchiseId}
+            </if>
+
+            <if test="filterType == 'code' and keyword != null">
+                AND o.code LIKE CONCAT('%', #{keyword}, '%')
+            </if>
+
+            <if test="filterType == 'product' and keyword != null">
+                AND p.name LIKE CONCAT('%', #{keyword}, '%')
+            </if>
+
+            <if test="filterType == 'status' and keyword != null">
+                AND o.status = #{keyword}
+            </if>
+
+            <if test="filterType == 'date' and keyword != null">
+                AND DATE(o.created_at) = #{keyword}
+            </if>
+        </where>
+        GROUP BY o.id
+        ORDER BY o.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <!-- 주문 개수 조회 (페이징 계산용) -->
+    <select id="countOrders" resultType="int"
+            parameterType="com.x1.frans.order.query.dto.OrderSearchConditionDto">
+        SELECT COUNT(DISTINCT o.id)
+        FROM orders o
+        JOIN product_order po ON o.id = po.order_id
+        JOIN product p ON po.product_id = p.id
+        <where>
+            <if test="franchiseId != null">
+                o.franchise_id = #{franchiseId}
+            </if>
+
+            <if test="filterType == 'code' and keyword != null">
+                AND o.code LIKE CONCAT('%', #{keyword}, '%')
+            </if>
+
+            <if test="filterType == 'product' and keyword != null">
+                AND p.name LIKE CONCAT('%', #{keyword}, '%')
+            </if>
+
+            <if test="filterType == 'status' and keyword != null">
+                AND o.status = #{keyword}
+            </if>
+
+            <if test="filterType == 'date' and keyword != null">
+                AND DATE(o.created_at) = #{keyword}
+            </if>
+        </where>
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #33 

## ✅ 작업 사항

- 주문 목록을 본사에서 조회할 수 있는 기능 구현.
- 사용자가 조건을 선택하여 조회할 수 있게 검색 필터 기능 함께 개발.
  - status (주문 상태)
  - code (주문 번호)
  - product (제품명)
  - date (주문일)

<br>

- SecurityConfig 에 보안 규칙 등록 

## 📸 스크린샷 (선택)
### 전체 가맹점
<img width="891" alt="image" src="https://github.com/user-attachments/assets/6b21779e-adf8-4263-8f53-7bdaec188d2e" />

### 특정 가맹점
<img width="906" alt="image" src="https://github.com/user-attachments/assets/88b1c1c2-48a2-4204-b69b-6f8b9172905c" />

### 특정 가맹점 + 코드 기준 검색
<img width="901" alt="image" src="https://github.com/user-attachments/assets/8972f2ae-b6a6-4ed5-ad8e-b6dd21b04b55" />

### 특정 가맹점 + 상품명 기준 검색
<img width="909" alt="image" src="https://github.com/user-attachments/assets/ee77e445-9840-47ea-820c-f37055a2a9f2" />

### 특정 가맹점 + 주문 상태 기준 검색
<img width="895" alt="image" src="https://github.com/user-attachments/assets/ea329cdd-3f45-47b7-8cff-35428f28120f" />

### 특정 가맹점 + 작성일 기준 검색
<img width="903" alt="image" src="https://github.com/user-attachments/assets/8f3c7855-499b-4afd-aaa0-faa11379cd47" />


## 👩‍💻 공유 포인트 및 논의 사항

추후에 추가할 내용입니다.
- [ ] sql 컨벤션 맞춰 작성 (xml 파일 저장 시 되돌아가는 오류로 인해 아직 컨벤션이 맞지 않는 상태)
- [ ] swagger 용 어노테이션 추가
