### PR TITLE
✨ feat: 가맹점용 주문 목록 조회 및 필터링 기능 구현

### DIFF
--- a/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
+++ b/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
@@ -1,0 +1,57 @@
+package com.x1.frans.order.query.controller;
+
+import com.x1.frans.order.query.dao.FranchiseOrderQueryMapper;
+import com.x1.frans.order.query.dto.OrderSearchConditionDto;
+import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
+import com.x1.frans.order.query.service.OrderQueryService;
+import com.x1.frans.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/franchise/orders")
+@RequiredArgsConstructor
+public class FranchiseOrderQueryController {
+
+    private final OrderQueryService orderQueryService;
+    private final FranchiseOrderQueryMapper franchiseOrderQueryMapper; // userId → franchiseId 조회용
+
+    @GetMapping
+    public OrderSearchPageResponseDto searchOrdersForFranchise(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) String filterType,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String code,
+            @RequestParam(required = false) String product,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Long userId = Long.valueOf(userDetails.getUserId());
+        Long franchiseId = franchiseOrderQueryMapper.findFranchiseIdByUserId(userId);
+
+        int offset = size * (page - 1);
+
+        OrderSearchConditionDto condition = OrderSearchConditionDto.builder()
+                .franchiseId(franchiseId)
+                .filterType(filterType)
+                .keyword(keyword)
+                .code(code)
+                .product(product)
+                .status(status)
+                .startDate(startDate)
+                .endDate(endDate)
+                .page(page)
+                .size(size)
+                .offset(offset)
+                .build();
+
+        return orderQueryService.searchOrders(condition);
+    }
+}

--- a/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
+++ b/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
@@ -8,8 +8,8 @@ import com.x1.frans.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,34 +23,14 @@ public class FranchiseOrderQueryController {
     @GetMapping
     public OrderSearchPageResponseDto searchOrdersForFranchise(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(required = false) String filterType,
-            @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) String code,
-            @RequestParam(required = false) String product,
-            @RequestParam(required = false) String status,
-            @RequestParam(required = false) String startDate,
-            @RequestParam(required = false) String endDate,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size
+            @ModelAttribute OrderSearchConditionDto condition
     ) {
         Long userId = Long.valueOf(userDetails.getUserId());
         Long franchiseId = franchiseOrderQueryMapper.findFranchiseIdByUserId(userId);
 
-        int offset = size * (page - 1);
-
-        OrderSearchConditionDto condition = OrderSearchConditionDto.builder()
-                .franchiseId(franchiseId)
-                .filterType(filterType)
-                .keyword(keyword)
-                .code(code)
-                .product(product)
-                .status(status)
-                .startDate(startDate)
-                .endDate(endDate)
-                .page(page)
-                .size(size)
-                .offset(offset)
-                .build();
+        int offset = condition.getSize() * (condition.getPage() - 1);
+        condition.setFranchiseId(franchiseId);
+        condition.setOffset(offset);
 
         return orderQueryService.searchOrders(condition);
     }

--- a/src/main/java/com/x1/frans/order/query/controller/OrderQueryController.java
+++ b/src/main/java/com/x1/frans/order/query/controller/OrderQueryController.java
@@ -5,8 +5,8 @@ import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 import com.x1.frans.order.query.service.OrderQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,20 +17,8 @@ public class OrderQueryController {
 
     @GetMapping
     public OrderSearchPageResponseDto searchOrdersPaged(
-            @RequestParam(required = false) Long franchiseId,
-            @RequestParam(required = false) String filterType,
-            @RequestParam(required = false) String keyword,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size
+            @ModelAttribute OrderSearchConditionDto condition
     ) {
-        OrderSearchConditionDto condition = OrderSearchConditionDto.builder()
-                .franchiseId(franchiseId)
-                .filterType(filterType)
-                .keyword(keyword)
-                .page(page)
-                .size(size)
-                .build();
-
         return orderQueryService.searchOrders(condition);
     }
 }

--- a/src/main/java/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.java
+++ b/src/main/java/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.java
@@ -1,0 +1,8 @@
+package com.x1.frans.order.query.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface FranchiseOrderQueryMapper {
+    Long findFranchiseIdByUserId(Long userId);
+}

--- a/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
@@ -1,12 +1,12 @@
 package com.x1.frans.order.query.dto;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
-@Builder
+@NoArgsConstructor
 public class OrderSearchConditionDto {
     private Long franchiseId;
     private String filterType;

--- a/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
@@ -11,6 +11,11 @@ public class OrderSearchConditionDto {
     private Long franchiseId;
     private String filterType;
     private String keyword;
+    private String code;
+    private String product;
+    private String status;
+    private String startDate;   // yyyy-MM-dd
+    private String endDate;
     private int page;
     private int size;           // 한 페이지당 목록 개수
     private int offset;         // size * (page -1)

--- a/src/main/resources/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.x1.frans.order.query.dao.FranchiseOrderQueryMapper">
+
+    <select id="findFranchiseIdByUserId" resultType="long">
+        SELECT id
+        FROM franchise
+        WHERE owner_id = #{userId}
+    </select>
+
+</mapper>

--- a/src/main/resources/com/x1/frans/order/query/dao/OrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/OrderQueryMapper.xml
@@ -35,20 +35,20 @@
                 o.franchise_id = #{franchiseId}
             </if>
 
-            <if test="filterType == 'code' and keyword != null">
-                AND o.code LIKE CONCAT('%', #{keyword}, '%')
+            <if test="code != null and code != ''">
+                AND o.code LIKE CONCAT('%', #{code}, '%')
             </if>
 
-            <if test="filterType == 'product' and keyword != null">
-                AND p.name LIKE CONCAT('%', #{keyword}, '%')
+            <if test="product != null and product != ''">
+                AND p.name LIKE CONCAT('%', #{product}, '%')
             </if>
 
-            <if test="filterType == 'status' and keyword != null">
-                AND o.status = #{keyword}
+            <if test="status != null and status != ''">
+                AND o.status LIKE CONCAT('%', #{status}, '%')
             </if>
 
-            <if test="filterType == 'date' and keyword != null">
-                AND DATE(o.created_at) = #{keyword}
+            <if test="startDate != null and endDate != null">
+                AND DATE(o.created_at) BETWEEN #{startDate} AND #{endDate}
             </if>
         </where>
         GROUP BY o.id
@@ -68,20 +68,20 @@
                 o.franchise_id = #{franchiseId}
             </if>
 
-            <if test="filterType == 'code' and keyword != null">
-                AND o.code LIKE CONCAT('%', #{keyword}, '%')
+            <if test="code != null and code != ''">
+                AND o.code LIKE CONCAT('%', #{code}, '%')
             </if>
 
-            <if test="filterType == 'product' and keyword != null">
-                AND p.name LIKE CONCAT('%', #{keyword}, '%')
+            <if test="product != null and product != ''">
+                AND p.name LIKE CONCAT('%', #{product}, '%')
             </if>
 
-            <if test="filterType == 'status' and keyword != null">
-                AND o.status = #{keyword}
+            <if test="status != null and status != ''">
+                AND o.status LIKE CONCAT('%', #{status}, '%')
             </if>
 
-            <if test="filterType == 'date' and keyword != null">
-                AND DATE(o.created_at) = #{keyword}
+            <if test="startDate != null and endDate != null">
+                AND DATE(o.created_at) BETWEEN #{startDate} AND #{endDate}
             </if>
         </where>
     </select>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #38 

## ✅ 작업 사항
- 해당 가맹점이 주문한 전체 목록을 조회하는 기능을 구현.

<br>

- 검색은 status, product, code 3개 중 하나로 검색 가능.
  - 또는 date와 함께 조회 가능.

<br>

- 기존 본사용 주문 목록 전체 조회 기능 중 필터 기능이 제대로 동작하지 않아, 
  - OrderSearchConditionDto
  - OrderQueryMapper.xml 파일을 수정.

## 📸 스크린샷 (선택)
<img width="303" alt="image" src="https://github.com/user-attachments/assets/f329bde4-68bc-463f-ab6f-2a413f691403" />

### 전체 조회
/api/franchise/orders?page=1&size=10

### 날짜 + 코드 조회
/api/franchise/orders?startDate=2025-06-01&endDate=2025-06-09&code=ORD
<img width="904" alt="image" src="https://github.com/user-attachments/assets/47478552-d408-445b-977f-03c7c300225c" />

### 날짜 + 상태 조회
/api/franchise/orders?startDate=2025-06-01&endDate=2025-06-09&status=접수

### 날짜 + 상품 조회
/api/franchise/orders?startDate=2025-06-01&endDate=2025-06-09&product=닭

### 코드 조회
/api/franchise/orders?code=ORD

### 상태 조회
/api/franchise/orders?status=접수

### 상품 조회
/api/franchise/orders?product=닭

## 👩‍💻 공유 포인트 및 논의 사항
