### PR TITLE
🚑 fix: CustomUserDetails 수정

### DIFF
--- a/src/main/java/com/x1/frans/order/command/application/controller/StoreOrderDeadlineController.java
+++ b/src/main/java/com/x1/frans/order/command/application/controller/StoreOrderDeadlineController.java
@@ -1,7 +1,7 @@
 package com.x1.frans.order.command.application.controller;
 
 import com.x1.frans.exception.InvalidTimeFormatException;
-import com.x1.frans.order.command.application.service.StoreOrderDeadlineService;
+import com.x1.frans.order.command.application.service.HqOrderCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,13 +17,13 @@ import java.time.format.DateTimeParseException;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/hq/orders/deadline")
+@RequestMapping("/api/hq/orders")
 @Tag(name = "📝 주문", description = "orders")
-public class StoreOrderDeadlineController {
+public class HqOrderCommandController {
 
-    private final StoreOrderDeadlineService storeOrderDeadlineService;
+    private final HqOrderCommandService hqOrderCommandService;
 
-    @PostMapping
+    @PostMapping("/deadline")
     @Operation(
             summary = "주문 마감 시간 등록 또는 수정",
             description = "주문 마감 시간을 등록하거나 기존 시간을 수정합니다. 파라미터는 HH:mm 형식의 문자열입니다."
@@ -34,7 +34,7 @@ public class StoreOrderDeadlineController {
     ) {
         try {
             LocalTime deadlineTime = LocalTime.parse(time);
-            boolean isCreated = storeOrderDeadlineService.createOrUpdateDeadline(deadlineTime);
+            boolean isCreated = hqOrderCommandService.createOrUpdateDeadline(deadlineTime);
             String message = isCreated ? "주문 마감 시간이 등록되었습니다." : "주문 마감 시간이 변경되었습니다.";
             return ResponseEntity.status(isCreated ? 201 : 200).body(message);
         } catch (DateTimeParseException e) {

--- a/src/main/java/com/x1/frans/security/CustomUserDetails.java
+++ b/src/main/java/com/x1/frans/security/CustomUserDetails.java
@@ -3,6 +3,7 @@ package com.x1.frans.security;
 import com.x1.frans.user.command.aggregate.UserEntity;
 import com.x1.frans.user.enums.UserType;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
@@ -30,7 +31,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return authorities;
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getType().name()));
     }
 
     public Long getUserId() {

--- a/src/main/java/com/x1/frans/user/query/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/user/query/service/UserQueryServiceImpl.java
@@ -10,7 +10,6 @@ import com.x1.frans.user.query.dto.SearchSupplierUserDTO;
 import com.x1.frans.user.query.repository.UserQueryMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -61,9 +60,6 @@ public class UserQueryServiceImpl implements UserQueryService {
         }
 
         List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
-
-        // TODO: 조회한 회원 별 권한 추가 로직 작성 필요
-        grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
 
         return new CustomUserDetails(loginUser, grantedAuthorities);
     }


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #64 

## ✅ 작업 사항
- CustomUserDetails의 getAuthorities() 메서드 수정
- 기존에는 DB의 user type (예: HQ, FRANCHISE)을 그대로 권한으로 사용했으나,
Spring Security의 hasRole() 메서드가 내부적으로 "ROLE_" + role 형식을 요구하기 때문에 권한 문자열에 "ROLE_" prefix를 추가함

<br>

- 기존에는 권한 값이 "HQ" 등으로 설정되어 있어 hasRole("HQ") 조건이 작동하지 않음
- Spring Security는 hasRole("X") 사용 시 "ROLE_X" 권한이 있어야 접근 허용됨
- 이를 해결하기 위해 user.getType() 기반 권한 생성 시 "ROLE_" prefix를 붙여 반환하도록 수정

## 📸 스크린샷 (선택)
<br>

## 👩‍💻 공유 포인트 및 논의 사항
