### PR TITLE
✨ feat: 결재 목록조회 기능 추가

### DIFF
--- a/src/main/java/com/x1/frans/approval/query/controller/ApprovalQueryController.java
+++ b/src/main/java/com/x1/frans/approval/query/controller/ApprovalQueryController.java
@@ -3,6 +3,7 @@ package com.x1.frans.approval.query.controller;
 import com.x1.frans.approval.query.dto.ApprovalListDTO;
 import com.x1.frans.approval.query.service.ApprovalQueryService;
 import com.x1.frans.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -25,11 +26,13 @@ public class ApprovalQueryController {
         this.approvalQueryService = approvalQueryService;
     }
 
+    @Operation(summary = "결재 목록 조회", description = "결재 리스트를 최신순으로 조회한다.")
     @GetMapping("/list")
     public ResponseEntity<List<ApprovalListDTO>> getApprovalList(@AuthenticationPrincipal CustomUserDetails user) {
         long userId = user.getUserId();
         List<ApprovalListDTO> list = approvalQueryService.getApprovalList(userId);
-        return ResponseEntity.ok(list);
 
+        return ResponseEntity.ok(list);
     }
+
 }

--- a/src/main/java/com/x1/frans/approval/query/controller/ApprovalQueryController.java
+++ b/src/main/java/com/x1/frans/approval/query/controller/ApprovalQueryController.java
@@ -1,0 +1,35 @@
+package com.x1.frans.approval.query.controller;
+
+import com.x1.frans.approval.query.dto.ApprovalListDTO;
+import com.x1.frans.approval.query.service.ApprovalQueryService;
+import com.x1.frans.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "결재", description = "결재 관련 API")
+@RequestMapping("/api/hq/approval")
+@RestController
+@Slf4j
+public class ApprovalQueryController {
+
+    private final ApprovalQueryService approvalQueryService;
+
+    public ApprovalQueryController(ApprovalQueryService approvalQueryService) {
+        this.approvalQueryService = approvalQueryService;
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalList(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalList(userId);
+        return ResponseEntity.ok(list);
+
+    }
+}

--- a/src/main/java/com/x1/frans/approval/query/controller/ApprovalQueryController.java
+++ b/src/main/java/com/x1/frans/approval/query/controller/ApprovalQueryController.java
@@ -24,11 +24,13 @@ public class ApprovalQueryController {
         this.approvalQueryService = approvalQueryService;
     }
 
-    @Operation(summary = "결재 목록 조회 - 상신 전체", description = "상신 전체 결재 리스트를 최신순으로 조회한다.")
-    @GetMapping("/list/submitted")
-    public ResponseEntity<List<ApprovalListDTO>> getApprovalListSubmitted(@AuthenticationPrincipal CustomUserDetails user) {
+    // 결재 상신 관련
+
+    @Operation(summary = "결재 목록 조회 - 상신 전체문서", description = "상신된 전체 결재 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/submitted/all")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListSubmittedAll(@AuthenticationPrincipal CustomUserDetails user) {
         long userId = user.getUserId();
-        List<ApprovalListDTO> list = approvalQueryService.getApprovalListSubmitted(userId);
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListSubmittedAll(userId);
 
         return ResponseEntity.ok(list);
     }
@@ -69,5 +71,166 @@ public class ApprovalQueryController {
 
         return ResponseEntity.ok(list);
     }
+
+    // 결재 수신 관련
+
+    @Operation(summary = "결재 목록 조회 - 수신 전체문서", description = "수신된 전체 결재 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/all")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedAll(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedAll(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 결재 대기", description = "결재 대기 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/pending")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedPending(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedPending(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 결재 예정", description = "결재 예정 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/upcoming")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedUpcoming(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedUpcoming(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 결재자 결재 완료 전체 문서", description = "결재자의 결재 완료 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/my-complete/all")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedMyCompletedAll(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedMyCompletedAll(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 결재자 승인 및 결재 완료문서", description = "결재자 승인 및 종료된 문서 전체 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/my-completed/approved")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedMyCompletedApproved(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedMyCompletedApproved(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 결재자 반려 및 결재 완료문서", description = "결재자 반려 및 종료된 문서 전체 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/my-completed/rejected")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedMyCompletedRejected(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedMyCompletedRejected(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 종료된 문서 전체", description = "종료된 문서 전체 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/closed")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedClosed(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedClosed(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 결재자 승인 및 종료된 문서", description = "결재자(ONLY 결재자) 승인 및 종료된 문서 전체 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/closed/approver/approved")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedClosedApproverApproved(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedClosedApproverApproved(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 결재자 반려 및 종료된 문서", description = "결재자(ONLY 결재자) 반려 및 종료된 문서 전체 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/closed/approver/rejected")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedClosedApproverRejected(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedClosedApproverRejected(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 협조자 승인 및 종료된 문서", description = "협조자 승인 및 종료된 문서 전체 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/closed/cooperator/approved")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedClosedCooperatorApproved(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedClosedCooperatorApproved(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 협조자 반려 및 종료된 문서", description = "협조자 반려 및 종료된 문서 전체 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/received/closed/cooperator/rejected")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReceivedClosedCooperatorRejected(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReceivedClosedCooperatorRejected(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+
+    @Operation(summary = "결재 목록 조회 - 전체 협조문서", description = "전체 협조문서 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/cooperate/all")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListCooperateAll(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListCooperateAll(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 협조 대기", description = "협조 대기 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/cooperate/pending")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListCooperatePending(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListCooperatePending(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 협조 승인", description = "협조 승인 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/cooperate/approved")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListCooperateApproved(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListCooperateApproved(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 협조 반려", description = "협조 반려 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/cooperate/rejected")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListCooperateRejected(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListCooperateRejected(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 참조문서 ", description = "참조문서 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/references")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListReferences(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListReferences(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 수신문서 ", description = "수신문서 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/notifications")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListNotifications(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListNotifications(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+
+
+
+
 
 }

--- a/src/main/java/com/x1/frans/approval/query/controller/ApprovalQueryController.java
+++ b/src/main/java/com/x1/frans/approval/query/controller/ApprovalQueryController.java
@@ -17,7 +17,6 @@ import java.util.List;
 @Tag(name = "결재", description = "결재 관련 API")
 @RequestMapping("/api/hq/approval")
 @RestController
-@Slf4j
 public class ApprovalQueryController {
 
     private final ApprovalQueryService approvalQueryService;
@@ -26,13 +25,23 @@ public class ApprovalQueryController {
         this.approvalQueryService = approvalQueryService;
     }
 
-    @Operation(summary = "결재 목록 조회", description = "결재 리스트를 최신순으로 조회한다.")
-    @GetMapping("/list")
-    public ResponseEntity<List<ApprovalListDTO>> getApprovalList(@AuthenticationPrincipal CustomUserDetails user) {
+    @Operation(summary = "결재 목록 조회 - 최신순", description = "전체 결재 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/newest")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListNewest(@AuthenticationPrincipal CustomUserDetails user) {
         long userId = user.getUserId();
-        List<ApprovalListDTO> list = approvalQueryService.getApprovalList(userId);
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListNewest(userId);
 
         return ResponseEntity.ok(list);
     }
+
+    @Operation(summary = "결재 목록 조회 - 오래된순", description = "전체 결재 리스트를 오래된순으로 조회한다.")
+    @GetMapping("/list/oldest")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListOldest(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListOldest(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
 
 }

--- a/src/main/java/com/x1/frans/approval/query/controller/ApprovalQueryController.java
+++ b/src/main/java/com/x1/frans/approval/query/controller/ApprovalQueryController.java
@@ -5,7 +5,6 @@ import com.x1.frans.approval.query.service.ApprovalQueryService;
 import com.x1.frans.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @Tag(name = "결재", description = "결재 관련 API")
-@RequestMapping("/api/hq/approval")
+@RequestMapping("/api/hq/approvals")
 @RestController
 public class ApprovalQueryController {
 
@@ -25,23 +24,50 @@ public class ApprovalQueryController {
         this.approvalQueryService = approvalQueryService;
     }
 
-    @Operation(summary = "결재 목록 조회 - 최신순", description = "전체 결재 리스트를 최신순으로 조회한다.")
-    @GetMapping("/list/newest")
-    public ResponseEntity<List<ApprovalListDTO>> getApprovalListNewest(@AuthenticationPrincipal CustomUserDetails user) {
+    @Operation(summary = "결재 목록 조회 - 상신 전체", description = "상신 전체 결재 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/submitted")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListSubmitted(@AuthenticationPrincipal CustomUserDetails user) {
         long userId = user.getUserId();
-        List<ApprovalListDTO> list = approvalQueryService.getApprovalListNewest(userId);
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListSubmitted(userId);
 
         return ResponseEntity.ok(list);
     }
 
-    @Operation(summary = "결재 목록 조회 - 오래된순", description = "전체 결재 리스트를 오래된순으로 조회한다.")
-    @GetMapping("/list/oldest")
-    public ResponseEntity<List<ApprovalListDTO>> getApprovalListOldest(@AuthenticationPrincipal CustomUserDetails user) {
+
+    @Operation(summary = "결재 목록 조회 - 임시저장", description = "임시저장된 결재 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/submitted/draft")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListDrafts(@AuthenticationPrincipal CustomUserDetails user) {
         long userId = user.getUserId();
-        List<ApprovalListDTO> list = approvalQueryService.getApprovalListOldest(userId);
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListDraft(userId);
 
         return ResponseEntity.ok(list);
     }
 
+    @Operation(summary = "결재 목록 조회 - 결재중", description = "결재중인 결재 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/submitted/in-progress")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListInProgress(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListInProgress(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 결재완료", description = "결재완료된 결재 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/submitted/approved")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListApproved(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListApproved(userId);
+
+        return ResponseEntity.ok(list);
+    }
+
+    @Operation(summary = "결재 목록 조회 - 결재반려", description = "결재반려된 결재 리스트를 최신순으로 조회한다.")
+    @GetMapping("/list/submitted/rejected")
+    public ResponseEntity<List<ApprovalListDTO>> getApprovalListRejected(@AuthenticationPrincipal CustomUserDetails user) {
+        long userId = user.getUserId();
+        List<ApprovalListDTO> list = approvalQueryService.getApprovalListRejected(userId);
+
+        return ResponseEntity.ok(list);
+    }
 
 }

--- a/src/main/java/com/x1/frans/approval/query/dto/ApprovalListDTO.java
+++ b/src/main/java/com/x1/frans/approval/query/dto/ApprovalListDTO.java
@@ -1,0 +1,61 @@
+package com.x1.frans.approval.query.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "결재 리스트 조회 DTO")
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class ApprovalListDTO {
+
+    @Schema(description = "결재 id")
+    private Long id;
+
+    @Schema(description = "결재 코드")
+    private String code;
+
+    @Schema(description = "결재 제목")
+    private String title;
+
+    @Schema(description = "결재 상태(결재완료, 결재반려, 결재중,임시저장)")
+    private String status;
+
+    @Schema(description = "기안일시")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "요청여부 (임시저장)")
+    private Boolean isRequested;
+
+    @Schema(description = "기안자명")
+    private String drafterName;
+
+    @Schema(description = "기안자 부서")
+    private String drafterDeptName;
+
+    @Schema(description = "기안자 직급")
+    private String drafterPositionName;
+
+    @Schema(description = "결재자명")
+    private String approverName;
+
+    @Schema(description = "결재자 부서")
+    private String approvalDeptName;
+
+    @Schema(description = "결재자 직급")
+    private String approvalPositionName;
+
+    @Schema(description = "결재선 순서")
+    private Integer seq;
+
+    @Schema(description = "결재 타입(결재, 협조, 참조, 수신)")
+    private String approvalType;
+
+    @Schema(description = "결재자 결재 상태(승인, 반려, 결재대기)")
+    private String approvalLineStatus;
+
+}

--- a/src/main/java/com/x1/frans/approval/query/repository/ApprovalQueryMapper.java
+++ b/src/main/java/com/x1/frans/approval/query/repository/ApprovalQueryMapper.java
@@ -1,0 +1,12 @@
+package com.x1.frans.approval.query.repository;
+
+import com.x1.frans.approval.query.dto.ApprovalListDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface ApprovalQueryMapper  {
+
+    List<ApprovalListDTO> getApprovalList(long userId);
+}

--- a/src/main/java/com/x1/frans/approval/query/repository/ApprovalQueryMapper.java
+++ b/src/main/java/com/x1/frans/approval/query/repository/ApprovalQueryMapper.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 @Mapper
 public interface ApprovalQueryMapper  {
+    
+    List<ApprovalListDTO> getApprovalListNewest(long userId);
 
-    List<ApprovalListDTO> getApprovalList(long userId);
+    List<ApprovalListDTO> getApprovalListOldest(long userId);
 }

--- a/src/main/java/com/x1/frans/approval/query/repository/ApprovalQueryMapper.java
+++ b/src/main/java/com/x1/frans/approval/query/repository/ApprovalQueryMapper.java
@@ -7,8 +7,15 @@ import java.util.List;
 
 @Mapper
 public interface ApprovalQueryMapper  {
-    
-    List<ApprovalListDTO> getApprovalListNewest(long userId);
 
-    List<ApprovalListDTO> getApprovalListOldest(long userId);
+    // 결재 상신 관련
+    List<ApprovalListDTO> getApprovalListSubmitted(long userId);
+
+    List<ApprovalListDTO> getApprovalListDraft(long userId);
+
+    List<ApprovalListDTO> getApprovalListInProgress(long userId);
+
+    List<ApprovalListDTO> getApprovalListApproved(long userId);
+
+    List<ApprovalListDTO> getApprovalListRejected(long userId);
 }

--- a/src/main/java/com/x1/frans/approval/query/repository/ApprovalQueryMapper.java
+++ b/src/main/java/com/x1/frans/approval/query/repository/ApprovalQueryMapper.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface ApprovalQueryMapper  {
 
     // 결재 상신 관련
-    List<ApprovalListDTO> getApprovalListSubmitted(long userId);
+    List<ApprovalListDTO> getApprovalListSubmittedAll(long userId);
 
     List<ApprovalListDTO> getApprovalListDraft(long userId);
 
@@ -18,4 +18,40 @@ public interface ApprovalQueryMapper  {
     List<ApprovalListDTO> getApprovalListApproved(long userId);
 
     List<ApprovalListDTO> getApprovalListRejected(long userId);
+
+    // 결재 수신 관련
+    List<ApprovalListDTO> getApprovalListReceivedAll(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedPending(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedUpcoming(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedMyCompletedAll(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedClosed(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedMyCompletedApproved(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedMyCompletedRejected(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedClosedApproverApproved(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedClosedApproverRejected(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedClosedCooperatorApproved(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedClosedCooperatorRejected(long userId);
+
+    List<ApprovalListDTO> getApprovalListCooperateAll(long userId);
+
+    List<ApprovalListDTO> getApprovalListCooperatePending(long userId);
+
+    List<ApprovalListDTO> getApprovalListCooperateApproved(long userId);
+
+    List<ApprovalListDTO> getApprovalListCooperateRejected(long userId);
+
+    List<ApprovalListDTO> getApprovalListReferences(long userId);
+
+    List<ApprovalListDTO> getApprovalListNotifications(long userId);
+
 }

--- a/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryService.java
@@ -5,7 +5,13 @@ import com.x1.frans.approval.query.dto.ApprovalListDTO;
 import java.util.List;
 
 public interface ApprovalQueryService {
-    List<ApprovalListDTO> getApprovalListNewest(long userId);
+    List<ApprovalListDTO> getApprovalListSubmitted(long userId);
 
-    List<ApprovalListDTO> getApprovalListOldest(long userId);
+    List<ApprovalListDTO> getApprovalListDraft(long userId);
+
+    List<ApprovalListDTO> getApprovalListInProgress(long userId);
+
+    List<ApprovalListDTO> getApprovalListApproved(long userId);
+
+    List<ApprovalListDTO> getApprovalListRejected(long userId);
 }

--- a/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryService.java
@@ -1,0 +1,9 @@
+package com.x1.frans.approval.query.service;
+
+import com.x1.frans.approval.query.dto.ApprovalListDTO;
+
+import java.util.List;
+
+public interface ApprovalQueryService {
+    List<ApprovalListDTO> getApprovalList(long userId);
+}

--- a/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryService.java
@@ -5,7 +5,7 @@ import com.x1.frans.approval.query.dto.ApprovalListDTO;
 import java.util.List;
 
 public interface ApprovalQueryService {
-    List<ApprovalListDTO> getApprovalListSubmitted(long userId);
+    List<ApprovalListDTO> getApprovalListSubmittedAll(long userId);
 
     List<ApprovalListDTO> getApprovalListDraft(long userId);
 
@@ -14,4 +14,39 @@ public interface ApprovalQueryService {
     List<ApprovalListDTO> getApprovalListApproved(long userId);
 
     List<ApprovalListDTO> getApprovalListRejected(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedAll(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedPending(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedUpcoming(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedMyCompletedAll(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedClosed(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedMyCompletedApproved(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedMyCompletedRejected(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedClosedApproverApproved(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedClosedApproverRejected(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedClosedCooperatorApproved(long userId);
+
+    List<ApprovalListDTO> getApprovalListReceivedClosedCooperatorRejected(long userId);
+
+    List<ApprovalListDTO> getApprovalListCooperateAll(long userId);
+
+    List<ApprovalListDTO> getApprovalListCooperatePending(long userId);
+
+    List<ApprovalListDTO> getApprovalListCooperateApproved(long userId);
+
+    List<ApprovalListDTO> getApprovalListCooperateRejected(long userId);
+
+    List<ApprovalListDTO> getApprovalListReferences(long userId);
+
+    List<ApprovalListDTO> getApprovalListNotifications(long userId);
+
 }

--- a/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryService.java
@@ -5,5 +5,7 @@ import com.x1.frans.approval.query.dto.ApprovalListDTO;
 import java.util.List;
 
 public interface ApprovalQueryService {
-    List<ApprovalListDTO> getApprovalList(long userId);
+    List<ApprovalListDTO> getApprovalListNewest(long userId);
+
+    List<ApprovalListDTO> getApprovalListOldest(long userId);
 }

--- a/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package com.x1.frans.approval.query.service;
+
+import com.x1.frans.approval.query.dto.ApprovalListDTO;
+import com.x1.frans.approval.query.repository.ApprovalQueryMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ApprovalQueryServiceImpl implements ApprovalQueryService {
+
+    private final ApprovalQueryMapper approvalQueryMapper;
+
+    @Autowired
+    public ApprovalQueryServiceImpl(ApprovalQueryMapper approvalQueryMapper) {
+        this.approvalQueryMapper = approvalQueryMapper;
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalList(long userId) {
+        return approvalQueryMapper.getApprovalList(userId);
+    }
+}

--- a/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryServiceImpl.java
@@ -18,8 +18,8 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
     }
 
     @Override
-    public List<ApprovalListDTO> getApprovalListSubmitted(long userId) {
-        return approvalQueryMapper.getApprovalListSubmitted(userId);
+    public List<ApprovalListDTO> getApprovalListSubmittedAll(long userId) {
+        return approvalQueryMapper.getApprovalListSubmittedAll(userId);
     }
 
 
@@ -41,5 +41,90 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
     @Override
     public List<ApprovalListDTO> getApprovalListRejected(long userId) {
         return approvalQueryMapper.getApprovalListRejected(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedAll(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedAll(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedPending(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedPending(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedUpcoming(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedUpcoming(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedMyCompletedAll(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedMyCompletedAll(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedClosed(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedClosed(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedMyCompletedApproved(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedMyCompletedApproved(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedMyCompletedRejected(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedMyCompletedRejected(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedClosedApproverApproved(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedClosedApproverApproved(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedClosedApproverRejected(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedClosedApproverRejected(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedClosedCooperatorApproved(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedClosedCooperatorApproved(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReceivedClosedCooperatorRejected(long userId) {
+        return approvalQueryMapper.getApprovalListReceivedClosedCooperatorRejected(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListCooperateAll(long userId) {
+        return approvalQueryMapper.getApprovalListCooperateAll(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListCooperatePending(long userId) {
+        return approvalQueryMapper.getApprovalListCooperatePending(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListCooperateApproved(long userId) {
+        return approvalQueryMapper.getApprovalListCooperateApproved(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListCooperateRejected(long userId) {
+        return approvalQueryMapper.getApprovalListCooperateRejected(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListReferences(long userId) {
+        return approvalQueryMapper.getApprovalListReferences(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListNotifications(long userId) {
+        return approvalQueryMapper.getApprovalListNotifications(userId);
     }
 }

--- a/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryServiceImpl.java
@@ -18,7 +18,12 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
     }
 
     @Override
-    public List<ApprovalListDTO> getApprovalList(long userId) {
-        return approvalQueryMapper.getApprovalList(userId);
+    public List<ApprovalListDTO> getApprovalListNewest(long userId) {
+        return approvalQueryMapper.getApprovalListNewest(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListOldest(long userId) {
+        return approvalQueryMapper.getApprovalListOldest(userId);
     }
 }

--- a/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryServiceImpl.java
@@ -18,12 +18,28 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
     }
 
     @Override
-    public List<ApprovalListDTO> getApprovalListNewest(long userId) {
-        return approvalQueryMapper.getApprovalListNewest(userId);
+    public List<ApprovalListDTO> getApprovalListSubmitted(long userId) {
+        return approvalQueryMapper.getApprovalListSubmitted(userId);
+    }
+
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListDraft(long userId) {
+        return approvalQueryMapper.getApprovalListDraft(userId);
     }
 
     @Override
-    public List<ApprovalListDTO> getApprovalListOldest(long userId) {
-        return approvalQueryMapper.getApprovalListOldest(userId);
+    public List<ApprovalListDTO> getApprovalListInProgress(long userId) {
+        return approvalQueryMapper.getApprovalListInProgress(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListApproved(long userId) {
+        return approvalQueryMapper.getApprovalListApproved(userId);
+    }
+
+    @Override
+    public List<ApprovalListDTO> getApprovalListRejected(long userId) {
+        return approvalQueryMapper.getApprovalListRejected(userId);
     }
 }

--- a/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
@@ -16,7 +16,7 @@
         <result property="approvalLineStatus" column="approval_line_status"/>
 
     </resultMap>
-    <select id="getApprovalList" resultMap="getApprovalListMap">
+    <select id="getApprovalListNewest" resultMap="getApprovalListMap">
         SELECT
                a.id
              , a.code
@@ -58,5 +58,49 @@
          WHERE drafter.id = #{userId}
             OR approver.id = #{userId}
          ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListOldest" resultMap="getApprovalListMap">
+        SELECT
+            a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+        FROM approval a
+                 LEFT JOIN approval_line l
+                           ON a.id = l.approval_id
+                               AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+                 LEFT JOIN user drafter
+                           ON a.user_id = drafter.id
+                 LEFT JOIN hq_user_detail hq_drafter
+                           ON hq_drafter.user_id = drafter.id
+                 LEFT JOIN department drafter_dept
+                           ON drafter_dept.id = hq_drafter.department_id
+                 LEFT JOIN position drafter_position
+                           ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+                 LEFT JOIN user approver
+                           ON l.user_id = approver.id
+                 LEFT JOIN hq_user_detail hq_approver
+                           ON hq_approver.user_id = approver.id
+                 LEFT JOIN department approver_dept
+                           ON approver_dept.id = hq_approver.department_id
+                 LEFT JOIN position approver_position
+                           ON approver_position.id = hq_approver.position_id
+        WHERE drafter.id = #{userId}
+           OR approver.id = #{userId}
+        ORDER BY a.created_at
     </select>
 </mapper>

--- a/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.x1.frans.approval.query.repository.ApprovalQueryMapper">
+    <resultMap id="getApprovalListMap" type="com.x1.frans.approval.query.dto.ApprovalListDTO">
+        <result property="createdAt" column="created_at"/>
+        <result property="isRequested" column="is_requested"/>
+        <result property="drafterName" column="drafter_name"/>
+        <result property="drafterDeptName" column="drafter_dept_name"/>
+        <result property="drafterPositionName" column="drafter_position_name"/>
+        <result property="approverName" column="approver_name"/>
+        <result property="approvalDeptName" column="approver_dept_name"/>
+        <result property="approvalPositionName" column="approver_position_name"/>
+        <result property="approvalType" column="approval_type"/>
+        <result property="approvalLineStatus" column="approval_line_status"/>
+
+    </resultMap>
+    <select id="getApprovalList" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+           AND a.degree = l.approval_degree
+
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE drafter.id = #{userId}
+            OR approver.id = #{userId}
+    </select>
+</mapper>

--- a/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
@@ -16,7 +16,8 @@
         <result property="approvalLineStatus" column="approval_line_status"/>
 
     </resultMap>
-    <select id="getApprovalListSubmitted" resultMap="getApprovalListMap">
+    <!-- 결재 수신 관련 -->
+    <select id="getApprovalListReceivedAll" resultMap="getApprovalListMap">
         SELECT
                a.id
              , a.code
@@ -56,6 +57,7 @@
           LEFT JOIN position approver_position
             ON approver_position.id = hq_approver.position_id
          WHERE drafter.id = #{userId}
+            OR approver.id = #{userId}
          ORDER BY a.created_at DESC
     </select>
 
@@ -98,7 +100,8 @@
             ON approver_dept.id = hq_approver.department_id
           LEFT JOIN position approver_position
             ON approver_position.id = hq_approver.position_id
-         WHERE drafter.id = #{userId} AND a.status = '임시저장'
+         WHERE drafter.id = #{userId}
+           AND a.status = '임시저장'
          ORDER BY a.created_at DESC
     </select>
 
@@ -141,7 +144,8 @@
             ON approver_dept.id = hq_approver.department_id
           LEFT JOIN position approver_position
             ON approver_position.id = hq_approver.position_id
-         WHERE drafter.id = #{userId} AND a.status = '결재 중'
+         WHERE drafter.id = #{userId}
+           AND a.status = '결재 중'
          ORDER BY a.created_at DESC
     </select>
 
@@ -184,7 +188,8 @@
             ON approver_dept.id = hq_approver.department_id
           LEFT JOIN position approver_position
             ON approver_position.id = hq_approver.position_id
-        WHERE drafter.id = #{userId} AND a.status = '결재 완료'
+        WHERE drafter.id = #{userId}
+          AND a.status = '결재 완료'
         ORDER BY a.created_at DESC
     </select>
 
@@ -227,7 +232,776 @@
             ON approver_dept.id = hq_approver.department_id
           LEFT JOIN position approver_position
             ON approver_position.id = hq_approver.position_id
-        WHERE drafter.id = #{userId} AND a.status = '결재 반려'
+        WHERE drafter.id = #{userId}
+          AND a.status = '결재 반려'
         ORDER BY a.created_at DESC
     </select>
+
+    <!-- 결재 수신 관련 -->
+    <select id="getApprovalListReceived" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+        -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+        -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListReceivedPending" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.status = '대기'
+           AND l.approval_type = '결재'
+         ORDER BY a.created_at DESC
+    </select>
+    <select id="getApprovalListReceivedUpcoming" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.status = '예정'
+           AND l.approval_type = '결재'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListReceivedMyCompletedAll" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.status IN ('승인', '반려')
+           AND l.approval_type IN ('결재', '협조')
+           AND a.status = '결재 중'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListReceivedMyCompletedApproved" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.status = '승인'
+           AND l.approval_type IN ('결재','협조')
+           AND a.status = '결재 중'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListReceivedMyCompletedRejected" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.status = '반려'
+           AND l.approval_type IN ('결재','협조')
+           AND a.status = '결재 중'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListReceivedClosed" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND a.status = '결재 완료'
+           AND l.approval_type IN ('결재','협조')
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListReceivedClosedApproverApproved" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.status = '승인'
+           AND l.approval_type = '결재'
+           AND a.status = '결재 완료'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListReceivedClosedApproverRejected" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.status = '반려'
+           AND l.approval_type = '결재'
+           AND a.status = '결재 완료'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListReceivedClosedCooperatorApproved" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+        FROM approval a
+                 LEFT JOIN approval_line l
+                           ON a.id = l.approval_id
+                               AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+                 LEFT JOIN user drafter
+                           ON a.user_id = drafter.id
+                 LEFT JOIN hq_user_detail hq_drafter
+                           ON hq_drafter.user_id = drafter.id
+                 LEFT JOIN department drafter_dept
+                           ON drafter_dept.id = hq_drafter.department_id
+                 LEFT JOIN position drafter_position
+                           ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+                 LEFT JOIN user approver
+                           ON l.user_id = approver.id
+                 LEFT JOIN hq_user_detail hq_approver
+                           ON hq_approver.user_id = approver.id
+                 LEFT JOIN department approver_dept
+                           ON approver_dept.id = hq_approver.department_id
+                 LEFT JOIN position approver_position
+                           ON approver_position.id = hq_approver.position_id
+        WHERE l.user_id = #{userId}
+          AND l.status = '승인'
+          AND l.approval_type = '협조'
+          AND a.status = '결재 완료'
+        ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListReceivedClosedCooperatorRejected" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+        WHERE l.user_id = #{userId}
+          AND l.status = '반려'
+          AND l.approval_type = '협조'
+          AND a.status = '결재 완료'
+        ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListCooperateAll" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.approval_type = '협조'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListCooperatePending" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.status = '대기'
+           AND l.approval_type = '협조'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListCooperateApproved" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.status = '승인'
+           AND l.approval_type = '협조'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListCooperateRejected" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.status = '반려'
+           AND l.approval_type = '협조'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListReferences" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.approval_type = '참조'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListNotifications" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+            -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+            -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE l.user_id = #{userId}
+           AND l.approval_type = '수신'
+         ORDER BY a.created_at DESC
+    </select>
+
 </mapper>

--- a/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
@@ -16,7 +16,7 @@
         <result property="approvalLineStatus" column="approval_line_status"/>
 
     </resultMap>
-    <select id="getApprovalListNewest" resultMap="getApprovalListMap">
+    <select id="getApprovalListSubmitted" resultMap="getApprovalListMap">
         SELECT
                a.id
              , a.code
@@ -56,13 +56,12 @@
           LEFT JOIN position approver_position
             ON approver_position.id = hq_approver.position_id
          WHERE drafter.id = #{userId}
-            OR approver.id = #{userId}
          ORDER BY a.created_at DESC
     </select>
 
-    <select id="getApprovalListOldest" resultMap="getApprovalListMap">
+    <select id="getApprovalListDraft" resultMap="getApprovalListMap">
         SELECT
-            a.id
+               a.id
              , a.code
              , a.title
              , a.status
@@ -77,30 +76,158 @@
              , l.seq
              , l.approval_type
              , l.status AS approval_line_status
-        FROM approval a
-                 LEFT JOIN approval_line l
-                           ON a.id = l.approval_id
-                               AND a.degree = l.approval_degree
-            -- 기안자 관련 조인
-                 LEFT JOIN user drafter
-                           ON a.user_id = drafter.id
-                 LEFT JOIN hq_user_detail hq_drafter
-                           ON hq_drafter.user_id = drafter.id
-                 LEFT JOIN department drafter_dept
-                           ON drafter_dept.id = hq_drafter.department_id
-                 LEFT JOIN position drafter_position
-                           ON drafter_position.id = hq_drafter.position_id
-            -- 결재자 관련 조인
-                 LEFT JOIN user approver
-                           ON l.user_id = approver.id
-                 LEFT JOIN hq_user_detail hq_approver
-                           ON hq_approver.user_id = approver.id
-                 LEFT JOIN department approver_dept
-                           ON approver_dept.id = hq_approver.department_id
-                 LEFT JOIN position approver_position
-                           ON approver_position.id = hq_approver.position_id
-        WHERE drafter.id = #{userId}
-           OR approver.id = #{userId}
-        ORDER BY a.created_at
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+          -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+          -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE drafter.id = #{userId} AND a.status = '임시저장'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListInProgress" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+          -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+          -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+         WHERE drafter.id = #{userId} AND a.status = '결재 중'
+         ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListApproved" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+          -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+          -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+        WHERE drafter.id = #{userId} AND a.status = '결재 완료'
+        ORDER BY a.created_at DESC
+    </select>
+
+    <select id="getApprovalListRejected" resultMap="getApprovalListMap">
+        SELECT
+               a.id
+             , a.code
+             , a.title
+             , a.status
+             , a.created_at
+             , a.is_requested
+             , drafter.name AS drafter_name
+             , drafter_dept.name AS drafter_dept_name
+             , drafter_position.name AS drafter_position_name
+             , approver.name AS approver_name
+             , approver_dept.name AS approver_dept_name
+             , approver_position.name AS approver_position_name
+             , l.seq
+             , l.approval_type
+             , l.status AS approval_line_status
+          FROM approval a
+          LEFT JOIN approval_line l
+            ON a.id = l.approval_id
+            AND a.degree = l.approval_degree
+          -- 기안자 관련 조인
+          LEFT JOIN user drafter
+            ON a.user_id = drafter.id
+          LEFT JOIN hq_user_detail hq_drafter
+            ON hq_drafter.user_id = drafter.id
+          LEFT JOIN department drafter_dept
+            ON drafter_dept.id = hq_drafter.department_id
+          LEFT JOIN position drafter_position
+            ON drafter_position.id = hq_drafter.position_id
+          -- 결재자 관련 조인
+          LEFT JOIN user approver
+            ON l.user_id = approver.id
+          LEFT JOIN hq_user_detail hq_approver
+            ON hq_approver.user_id = approver.id
+          LEFT JOIN department approver_dept
+            ON approver_dept.id = hq_approver.department_id
+          LEFT JOIN position approver_position
+            ON approver_position.id = hq_approver.position_id
+        WHERE drafter.id = #{userId} AND a.status = '결재 반려'
+        ORDER BY a.created_at DESC
     </select>
 </mapper>

--- a/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
@@ -37,7 +37,7 @@
           LEFT JOIN approval_line l
             ON a.id = l.approval_id
            AND a.degree = l.approval_degree
-
+            -- 기안자 관련 조인
           LEFT JOIN user drafter
             ON a.user_id = drafter.id
           LEFT JOIN hq_user_detail hq_drafter
@@ -46,7 +46,7 @@
             ON drafter_dept.id = hq_drafter.department_id
           LEFT JOIN position drafter_position
             ON drafter_position.id = hq_drafter.position_id
-
+            -- 결재자 관련 조인
           LEFT JOIN user approver
             ON l.user_id = approver.id
           LEFT JOIN hq_user_detail hq_approver
@@ -57,5 +57,6 @@
             ON approver_position.id = hq_approver.position_id
          WHERE drafter.id = #{userId}
             OR approver.id = #{userId}
+         ORDER BY a.created_at DESC
     </select>
 </mapper>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #71 

## ✅ 작업 사항
해당 결재문서에 관련된(기안자 혹은 결재자) userId를 뽑아 조회가능하도록 했습니다.
<br>
결재상신 전체, 임시저장, 결재 중, 결재 완료, 결재 반려된 결재 목록 조회를 구현했습니다.
<br>

## 📸 스크린샷 
<img width="968" alt="스크린샷 2025-06-12 12 21 06" src="https://github.com/user-attachments/assets/aa8948db-04eb-4fd8-a0b7-c8c72ecf436a" />



<br>

## 👩‍💻 공유 포인트 및 논의 사항

