### PR TITLE
✨ feat: 주문 상태 관리를 위한 OrderStatus enum 정의

### DIFF
--- a/src/main/java/com/x1/frans/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/x1/frans/order/command/domain/aggregate/Order.java
@@ -3,6 +3,7 @@ package com.x1.frans.order.command.domain.aggregate;
 import com.x1.frans.exception.InvalidOrderRejectConditionException;
 import com.x1.frans.exception.OrderRejectReasonRequiredException;
 import com.x1.frans.franchise.command.domain.aggregate.FranchiseEntity;
+import com.x1.frans.order.command.domain.vo.OrderStatus;
 import com.x1.frans.user.command.aggregate.UserEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -25,8 +26,9 @@ public class Order {
     @Column(name = "code", nullable = false, unique = true)
     private String code;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    private String status;
+    private OrderStatus status;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
@@ -56,7 +58,7 @@ public class Order {
     private Delivery delivery;
 
     public void reject(String reason) {
-        if (!status.equals("검토중") && !status.equals("검토 완료")) {
+        if (status != OrderStatus.REVIEWING && status != OrderStatus.REVIEW_COMPLETED) {
             throw new InvalidOrderRejectConditionException("해당 주문 상태에서는 반려할 수 없습니다.");
         }
 
@@ -64,17 +66,17 @@ public class Order {
             throw new OrderRejectReasonRequiredException("반려 사유는 필수입니다.");
         }
 
-        this.status = "반려";
+        this.status = OrderStatus.REJECTED;
         this.rejectedReason = reason;
         this.rejectedAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
 
     public void markReviewComplete() {
-        if (!"검토중".equals(this.status)) {
+        if (this.status != OrderStatus.REVIEWING) {
             throw new InvalidOrderRejectConditionException("검토중 상태에서만 검토 완료로 변경할 수 있습니다.");
         }
-        this.status = "검토 완료";
+        this.status = OrderStatus.REVIEW_COMPLETED;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/x1/frans/order/command/domain/vo/OrderStatus.java
+++ b/src/main/java/com/x1/frans/order/command/domain/vo/OrderStatus.java
@@ -1,0 +1,25 @@
+package com.x1.frans.order.command.domain.vo;
+
+public enum OrderStatus {
+
+    WAITING_FOR_RECEIPT("접수 대기"),
+    RECEIPT_CANCELED("접수 취소"),
+    REJECTED("반려"),
+    REVIEWING("검토 중"),
+    REVIEW_COMPLETED("검토 완료"),
+    APPROVED("결재 완료"),
+    READY_FOR_DELIVERY("배송 준비 중"),
+    DELIVERING("배송 중"),
+    DELIVERED("배송 완료");
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}
+


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #81 

## ✅ 작업 사항
- 주문 상태를 명확히 구분하고 일관된 로직 처리를 위해 OrderStatus enum을 새로 정의하였습니다.
- 각 상태에 한글 description 추가 (`getDescription()` 통해 사용 가능)

### OrderStatus enum 생성 및 9개 상태 정의
  - WAITING_FOR_RECEIPT (접수 대기)
  - RECEIPT_CANCELED (접수 취소)
  - REJECTED (반려)
  - REVIEWING (검토 중)
  - REVIEW_COMPLETED (검토 완료)
  - APPROVED (결재 완료)
  - READY_FOR_DELIVERY (배송 준비 중)
  - DELIVERING (배송 중)
  - DELIVERED (배송 완료)

## 📸 스크린샷 (선택)
<img width="474" alt="image" src="https://github.com/user-attachments/assets/be4c71be-e3ba-4f59-9645-93057a345332" />

## 👩‍💻 공유 포인트 및 논의 사항
- 추후 상태값 변경 로직이나 승인/반려 기능 등과 연동 예정
- Java enum에 맞게 status 값은 영문 enum name 기준으로 저장되어야 하므로, orders 테이블 쪽 DDL을 수정하였습니다.
