### PR TITLE
✨ feat: 검토 취소하여 주문 상태를 검토 중으로 변경

### DIFF
--- a/src/main/java/com/x1/frans/order/command/application/controller/HqOrderCommandController.java
+++ b/src/main/java/com/x1/frans/order/command/application/controller/HqOrderCommandController.java
@@ -61,7 +61,7 @@ public class HqOrderCommandController {
 
     @PatchMapping("/{orderId}/review-complete")
     @Operation(
-            summary = "주문 상태 변경 (검토중 -> 검토 완료)",
+            summary = "주문 상태 변경 (검토 중 -> 검토 완료)",
             description = "검토중인 주문을 검토 완료로 변경합니다."
     )
     public ResponseEntity<Void> completeReview(
@@ -74,6 +74,10 @@ public class HqOrderCommandController {
     }
 
     @PatchMapping("/{orderId}/review-cancel")
+    @Operation(
+            summary = "주문 상태 변경 (검토 완료 -> 검토 중)",
+            description = "검토 완료된 주문을 검토 취소 처리하여 검토 중으로 변경합니다."
+    )
     public ResponseEntity<Void> cancelReview(
             @PathVariable Long orderId,
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/x1/frans/order/command/application/controller/HqOrderCommandController.java
+++ b/src/main/java/com/x1/frans/order/command/application/controller/HqOrderCommandController.java
@@ -72,4 +72,14 @@ public class HqOrderCommandController {
 
         return ResponseEntity.ok().build();
     }
+
+    @PatchMapping("/{orderId}/review-cancel")
+    public ResponseEntity<Void> cancelReview(
+            @PathVariable Long orderId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        hqOrderCommandService.cancelReviewComplete(orderId, userDetails.getUserId());
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandService.java
+++ b/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandService.java
@@ -8,4 +8,6 @@ public interface HqOrderCommandService {
     void rejectOrder(Long orderId, String reason, Long userId);
 
     void markReviewComplete(Long orderId, Long userId);
+
+    void cancelReviewComplete(Long orderId, Long userId);
 }

--- a/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandServiceImpl.java
@@ -56,6 +56,13 @@ public class HqOrderCommandServiceImpl implements HqOrderCommandService {
         order.markReviewComplete();
     }
 
+    @Override
+    @Transactional
+    public void cancelReviewComplete(Long orderId, Long userId) {
+        Order order = getAuthorizedOrder(orderId, userId);
+        order.cancelReviewComplete();
+    }
+
     private Order getAuthorizedOrder(Long orderId, Long userId) {
         Order order = orderCommandRepository.findById(orderId)
                 .orElseThrow(() -> new OrderNotFoundException("주문을 찾을 수 없습니다."));

--- a/src/main/java/com/x1/frans/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/x1/frans/order/command/domain/aggregate/Order.java
@@ -79,4 +79,12 @@ public class Order {
         this.status = OrderStatus.REVIEW_COMPLETED;
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void cancelReviewComplete() {
+        if (this.status != OrderStatus.REVIEW_COMPLETED) {
+            throw new InvalidOrderRejectConditionException("검토 완료 상태에서만 검토중으로 변경할 수 있습니다.");
+        }
+        this.status = OrderStatus.REVIEWING;
+        this.updatedAt = LocalDateTime.now();
+    }
 }


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #84 

## ✅ 작업 사항
- 주문 상태가 REVIEW_COMPLETED (검토 완료) 인 주문을 검토 취소하면 REVIEWING (검토 중)으로 변경되는 기능 구현
- 다른 주문 상태일 경우 InvalidOrderRejectConditionException 예외 발생


## 📸 스크린샷 (선택)
### 검토 취소했을 떄
<img width="973" alt="image" src="https://github.com/user-attachments/assets/dd3a8790-6b69-497a-b76e-29bb925ab542" />

### 주문 상태가 검토 완료가 아닌 경우
<img width="974" alt="image" src="https://github.com/user-attachments/assets/daf96718-327e-4392-8774-b92d7db66844" />

### 본인이 속한 부서가 담당하는 가맹점이 아닌 경우
<img width="961" alt="image" src="https://github.com/user-attachments/assets/a2f1a7f9-b95c-490c-b32e-5ad8f3e0af5e" />

### 가맹점이 존재하지 않는 경우
<img width="964" alt="image" src="https://github.com/user-attachments/assets/44455003-00bd-4391-bbc5-3b79f78a46a4" />



## 👩‍💻 공유 포인트 및 논의 사항
