### PR TITLE
✨ feat: 1주일 이내 배송완료된 주문 목록 조회

### DIFF
--- a/src/main/java/com/x1/frans/delivery/enums/DeliveryStatus.java
+++ b/src/main/java/com/x1/frans/delivery/enums/DeliveryStatus.java
@@ -1,0 +1,21 @@
+package com.x1.frans.delivery.enums;
+
+public enum DeliveryStatus {
+
+    UNREGISTERED("미등록"),
+    READY_FOR_DELIVERY("배송 준비 중"),
+    DELIVERING("배송 중"),
+    DELIVERED("배송 완료"),
+    PICKING_UP("반품 수거 중"),
+    PICKED_UP("반품 수거 완료");
+
+    private final String description;
+
+    DeliveryStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/x1/frans/returns/enums/ReturnStatus.java
+++ b/src/main/java/com/x1/frans/returns/enums/ReturnStatus.java
@@ -1,0 +1,21 @@
+package com.x1.frans.returns.enums;
+
+public enum ReturnStatus {
+    WAITING_FOR_RECEIPT("접수 대기"),
+    REJECTED("반려"),
+    REVIEW_COMPLETED("검토 완료"),
+    APPROVED("결재 완료"),
+    PICKING_UP("반품 수거 중"),
+    PICKED_UP("반품 수거 완료"),
+    COMPLETED("반품 완료");
+
+    private final String description;
+
+    ReturnStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/x1/frans/returns/query/controller/ReturnQueryController.java
+++ b/src/main/java/com/x1/frans/returns/query/controller/ReturnQueryController.java
@@ -1,4 +1,48 @@
 package com.x1.frans.returns.query.controller;
 
+import com.x1.frans.franchise.query.service.FranchiseQueryService;
+import com.x1.frans.returns.query.dto.ShippedOrderDTO;
+import com.x1.frans.returns.query.service.ReturnQueryService;
+import com.x1.frans.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.query.Param;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "가맹점", description = "가맹점 관련 API")
+@RestController
+@RequestMapping("api/franchise")
 public class ReturnQueryController {
+
+    private final ReturnQueryService returnQueryService;
+
+    @Autowired
+    public ReturnQueryController(ReturnQueryService returnQueryService, FranchiseQueryService franchiseQueryService) {
+        this.returnQueryService = returnQueryService;
+    }
+
+    @Operation(summary = "반품 등록 시 주문 목록 조회", description = "반품 등록 시 해당 가맹점의 주문 목록 중 최근 1주일 이내 배송이 완료된 목록을 조회할 수 있다.")
+    @GetMapping("{franchiseId}/return/regist/orders")
+    public ResponseEntity<List<ShippedOrderDTO>> findDeliveredOrdersWithinLastWeek
+                                                (@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                 @PathVariable("franchiseId") Long franchiseId) {
+        Long userId = userDetails.getUserId();
+        List<ShippedOrderDTO> list = returnQueryService.findDeliveredOrdersWithinLastWeek(userId, franchiseId);
+
+        System.out.println(userId);
+        System.out.println(franchiseId);
+
+
+        return ResponseEntity.ok(list);
+
+    }
+
 }

--- a/src/main/java/com/x1/frans/returns/query/dto/ShippedOrderDTO.java
+++ b/src/main/java/com/x1/frans/returns/query/dto/ShippedOrderDTO.java
@@ -1,4 +1,22 @@
 package com.x1.frans.returns.query.dto;
 
+import com.x1.frans.order.command.domain.vo.OrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ShippedOrderDTO {
+
+    private Long id;
+    private String code;
+    private LocalDateTime createdAt;
+    private LocalDateTime deliveredAt;
+    private BigDecimal totalAmount;
+    private OrderStatus status;
 }

--- a/src/main/java/com/x1/frans/returns/query/repository/ReturnQueryMapper.java
+++ b/src/main/java/com/x1/frans/returns/query/repository/ReturnQueryMapper.java
@@ -1,4 +1,12 @@
 package com.x1.frans.returns.query.repository;
 
-public class ReturnQueryMapper {
+import com.x1.frans.returns.query.dto.ShippedOrderDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface ReturnQueryMapper {
+    List<ShippedOrderDTO> findDeliveredOrdersWithinLastWeek(@Param("userId") Long userId, @Param("franchiseId") Long franchiseId);
 }

--- a/src/main/java/com/x1/frans/returns/query/service/ReturnQueryService.java
+++ b/src/main/java/com/x1/frans/returns/query/service/ReturnQueryService.java
@@ -1,4 +1,12 @@
 package com.x1.frans.returns.query.service;
 
+import com.x1.frans.returns.query.dto.ShippedOrderDTO;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
 public interface ReturnQueryService {
+
+    List<ShippedOrderDTO> findDeliveredOrdersWithinLastWeek(Long userId, Long FranchiseId);
+
 }

--- a/src/main/java/com/x1/frans/returns/query/service/ReturnQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/returns/query/service/ReturnQueryServiceImpl.java
@@ -1,4 +1,24 @@
 package com.x1.frans.returns.query.service;
 
-public class ReturnQueryServiceImpl {
+import com.x1.frans.returns.query.dto.ShippedOrderDTO;
+import com.x1.frans.returns.query.repository.ReturnQueryMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ReturnQueryServiceImpl implements ReturnQueryService {
+
+    private final ReturnQueryMapper returnQueryMapper;
+
+    @Autowired
+    public ReturnQueryServiceImpl(ReturnQueryMapper returnQueryMapper) {
+        this.returnQueryMapper = returnQueryMapper;
+    }
+
+    @Override
+    public List<ShippedOrderDTO> findDeliveredOrdersWithinLastWeek(Long userId, Long franchiseId) {
+        return returnQueryMapper.findDeliveredOrdersWithinLastWeek(userId, franchiseId);
+    }
 }

--- a/src/main/resources/com/x1/frans/returns/query/repository/ReturnQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/returns/query/repository/ReturnQueryMapper.xml
@@ -3,5 +3,27 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.x1.frans.returns.query.repository.ReturnQueryMapper">
-
+    <resultMap id="shippedOrderResultMap" type="com.x1.frans.returns.query.dto.ShippedOrderDTO">
+        <id property="id" column="id"/>
+        <result property="code" column="code"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="deliveredAt" column="delivered_at"/>
+        <result property="totalAmount" column="total_amount"/>
+        <result property="status" column="status"/>
+    </resultMap>
+    <select id="findDeliveredOrdersWithinLastWeek" resultMap="shippedOrderResultMap">
+        SELECT
+            o.`id`,
+            o.`code`,
+            o.`created_at`,
+            d.`delivered_at`,
+            o.`total_amount`,
+            o.`status`
+        FROM `orders` o
+        JOIN `delivery` d ON o.`delivery_id` = d.`id`
+        WHERE o.`franchise_id` = #{franchiseId}
+          AND o.`user_id` = #{userId}
+          AND o.`status` = 'DELIVERED'
+          AND d.delivered_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+    </select>
 </mapper>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #45

## ✅ 작업 사항
<br>
반품 등록시 1주일 이내에 배송 완료된 주문 목록을 조회할 수 있다. 

## 📸 스크린샷 (선택)
<br>
<img width="745" alt="image" src="https://github.com/user-attachments/assets/0834f6d9-a26b-4b59-9cf5-4e2a19c8b839" />


## 👩‍💻 공유 포인트 및 논의 사항
