### PR TITLE
✨ feat: 배송 정보 등록, 수정 구현

### DIFF
--- a/src/main/java/com/x1/frans/order/command/application/controller/HqOrderCommandController.java
+++ b/src/main/java/com/x1/frans/order/command/application/controller/HqOrderCommandController.java
@@ -105,7 +105,10 @@ public class HqOrderCommandController {
     }
 
     @PatchMapping("/{orderId}/delivery")
-    @Operation(summary = "배송 정보 등록 또는 수정", description = "배송 준비 중 상태의 주문에 배송 정보를 입력하고 상태를 배송 중으로 변경합니다.")
+    @Operation(
+            summary = "배송 정보 등록 또는 수정",
+            description = "결재 완료 상태의 주문에 배송 정보를 입력하고 상태를 배송 중으로 변경합니다. (주문 상태도 같이 변경)"
+    )
     public ResponseEntity<Void> registerOrUpdateDelivery(
             @PathVariable Long orderId,
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/x1/frans/order/command/application/controller/HqOrderCommandController.java
+++ b/src/main/java/com/x1/frans/order/command/application/controller/HqOrderCommandController.java
@@ -1,6 +1,7 @@
 package com.x1.frans.order.command.application.controller;
 
 import com.x1.frans.exception.InvalidTimeFormatException;
+import com.x1.frans.order.command.application.dto.DeliveryInfoRequestDto;
 import com.x1.frans.order.command.application.dto.OrderRejectRequestDto;
 import com.x1.frans.order.command.application.dto.OrderStatusUpdateRequestDto;
 import com.x1.frans.order.command.application.service.HqOrderCommandService;
@@ -100,6 +101,17 @@ public class HqOrderCommandController {
     ) {
         hqOrderCommandService.updateOrderStatusAndDelivery(orderId, dto, userDetails.getUserId());
 
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{orderId}/delivery")
+    @Operation(summary = "배송 정보 등록 또는 수정", description = "배송 준비 중 상태의 주문에 배송 정보를 입력하고 상태를 배송 중으로 변경합니다.")
+    public ResponseEntity<Void> registerOrUpdateDelivery(
+            @PathVariable Long orderId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody DeliveryInfoRequestDto dto
+    ) {
+        hqOrderCommandService.registerOrUpdateDelivery(orderId, userDetails.getUserId(), dto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/x1/frans/order/command/application/dto/DeliveryInfoRequestDto.java
+++ b/src/main/java/com/x1/frans/order/command/application/dto/DeliveryInfoRequestDto.java
@@ -1,0 +1,20 @@
+package com.x1.frans.order.command.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class DeliveryInfoRequestDto {
+
+    @NotBlank(message = "배송 업체는 필수입니다.")
+    private String deliveryCompany;
+
+    @NotBlank(message = "운송장 번호는 필수입니다.")
+    private String trackingNumber;
+
+    @NotBlank(message = "배송 기사명은 필수입니다.")
+    private String name;
+
+    @NotBlank(message = "배송 기사 연락처는 필수입니다.")
+    private String phone;
+}

--- a/src/main/java/com/x1/frans/order/command/application/dto/OrderStatusUpdateRequestDto.java
+++ b/src/main/java/com/x1/frans/order/command/application/dto/OrderStatusUpdateRequestDto.java
@@ -1,10 +1,12 @@
 package com.x1.frans.order.command.application.dto;
 
 import com.x1.frans.order.command.domain.vo.OrderStatus;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class OrderStatusUpdateRequestDto {
 
+    @NotBlank(message = "주문 상태는 필수입니다.")
     private OrderStatus status;
 }

--- a/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandService.java
+++ b/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandService.java
@@ -1,5 +1,6 @@
 package com.x1.frans.order.command.application.service;
 
+import com.x1.frans.order.command.application.dto.DeliveryInfoRequestDto;
 import com.x1.frans.order.command.application.dto.OrderStatusUpdateRequestDto;
 
 import java.time.LocalTime;
@@ -14,4 +15,6 @@ public interface HqOrderCommandService {
     void cancelReviewComplete(Long orderId, Long userId);
 
     void updateOrderStatusAndDelivery(Long orderId, OrderStatusUpdateRequestDto dto, Long userId);
+
+    void registerOrUpdateDelivery(Long orderId, Long userId, DeliveryInfoRequestDto dto);
 }

--- a/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandServiceImpl.java
@@ -76,8 +76,8 @@ public class HqOrderCommandServiceImpl implements HqOrderCommandService {
     public void registerOrUpdateDelivery(Long orderId, Long userId, DeliveryInfoRequestDto dto) {
         Order order = orderAuthorizationService.getAuthorizedOrder(orderId, userId);
 
-        if (!order.getStatus().equals(OrderStatus.APPROVED)) {
-            throw new IllegalStateException("배송 정보는 '결재 완료' 상태에서만 등록할 수 있습니다.");
+        if (!(order.getStatus().equals(OrderStatus.APPROVED) || order.getStatus().equals(OrderStatus.DELIVERING))) {
+            throw new IllegalStateException("배송 정보는 '결재 완료' 또는 '배송 중' 상태에서만 등록/수정할 수 있습니다.");
         }
 
         Delivery delivery = order.getDelivery();

--- a/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandServiceImpl.java
@@ -1,11 +1,16 @@
 package com.x1.frans.order.command.application.service;
 
 import com.x1.frans.exception.DuplicateDeadlineTimeException;
+import com.x1.frans.order.command.application.dto.DeliveryInfoRequestDto;
 import com.x1.frans.order.command.application.dto.OrderStatusUpdateRequestDto;
+import com.x1.frans.order.command.domain.aggregate.Delivery;
 import com.x1.frans.order.command.domain.aggregate.Order;
 import com.x1.frans.order.command.domain.aggregate.StoreOrderDeadline;
+import com.x1.frans.order.command.domain.repository.DeliveryRepository;
 import com.x1.frans.order.command.domain.repository.StoreOrderDeadlineRepository;
+import com.x1.frans.order.command.domain.vo.OrderStatus;
 import com.x1.frans.order.common.OrderAuthorizationService;
+import com.x1.frans.user.enums.DeliveryStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +22,7 @@ import java.time.LocalTime;
 public class HqOrderCommandServiceImpl implements HqOrderCommandService {
 
     private final StoreOrderDeadlineRepository storeOrderDeadlineRepository;
+    private final DeliveryRepository deliveryRepository;
     private final OrderAuthorizationService orderAuthorizationService;
 
     @Override
@@ -63,6 +69,43 @@ public class HqOrderCommandServiceImpl implements HqOrderCommandService {
     public void updateOrderStatusAndDelivery(Long orderId, OrderStatusUpdateRequestDto dto, Long userId) {
         Order order = orderAuthorizationService.getAuthorizedOrder(orderId, userId);
         order.updateStatus(dto.getStatus());
+    }
+
+    @Override
+    @Transactional
+    public void registerOrUpdateDelivery(Long orderId, Long userId, DeliveryInfoRequestDto dto) {
+        Order order = orderAuthorizationService.getAuthorizedOrder(orderId, userId);
+
+        if (!order.getStatus().equals(OrderStatus.APPROVED)) {
+            throw new IllegalStateException("배송 정보는 '결재 완료' 상태에서만 등록할 수 있습니다.");
+        }
+
+        Delivery delivery = order.getDelivery();
+        boolean isNew = false;
+
+        if (delivery == null) {
+            // 최초 등록 (배송 상태 - '배송 중')
+            delivery = Delivery.builder()
+                    .code("DLV-" + System.currentTimeMillis())
+                    .status(DeliveryStatus.DELIVERING)
+                    .deliveryCompany(dto.getDeliveryCompany())
+                    .trackingNumber(dto.getTrackingNumber())
+                    .name(dto.getName())
+                    .phone(dto.getPhone())
+                    .build();
+            isNew = true;
+        } else {
+            // 수정 (배송 상태 - 유지)
+            delivery.updateDeliveryInfo(dto.getDeliveryCompany(), dto.getTrackingNumber(), dto.getName(), dto.getPhone());
+        }
+
+        deliveryRepository.save(delivery);
+        order.assignDelivery(delivery);
+
+        if (isNew) {
+            // 최초 등록 시에만 주문 상태도 배송 중으로 변경
+            order.updateStatus(OrderStatus.DELIVERING);
+        }
     }
 
 

--- a/src/main/java/com/x1/frans/order/command/domain/aggregate/Delivery.java
+++ b/src/main/java/com/x1/frans/order/command/domain/aggregate/Delivery.java
@@ -1,5 +1,6 @@
 package com.x1.frans.order.command.domain.aggregate;
 
+import com.x1.frans.user.enums.DeliveryStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,8 +21,9 @@ public class Delivery {
     @Column(nullable = false, unique = true)
     private String code;
 
-    @Column(nullable = false)
-    private String status;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private DeliveryStatus status;
 
     @Column(name = "delivery_company")
     private String deliveryCompany;
@@ -53,4 +55,12 @@ public class Delivery {
     public void preUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void updateDeliveryInfo(String deliveryCompany, String trackingNumber, String name, String phone) {
+        this.deliveryCompany = deliveryCompany;
+        this.trackingNumber = trackingNumber;
+        this.name = name;
+        this.phone = phone;
+    }
+
 }

--- a/src/main/java/com/x1/frans/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/x1/frans/order/command/domain/aggregate/Order.java
@@ -104,11 +104,13 @@ public class Order {
 
     private boolean isValidTransition(OrderStatus current, OrderStatus target) {
         return switch (current) {
-            case APPROVED -> Set.of(OrderStatus.READY_FOR_DELIVERY, OrderStatus.DELIVERING).contains(target);
-            case READY_FOR_DELIVERY -> Set.of(OrderStatus.APPROVED, OrderStatus.DELIVERING).contains(target);
-            case DELIVERING -> Set.of(OrderStatus.DELIVERED, OrderStatus.READY_FOR_DELIVERY).contains(target);
-            case DELIVERED -> Set.of(OrderStatus.DELIVERING).contains(target);
+            case APPROVED, DELIVERED -> Set.of(OrderStatus.DELIVERING).contains(target);
+            case DELIVERING -> Set.of(OrderStatus.DELIVERED).contains(target);
             default -> false;
         };
+    }
+
+    public void assignDelivery(Delivery delivery) {
+        this.delivery = delivery;
     }
 }

--- a/src/main/java/com/x1/frans/order/command/domain/repository/DeliveryRepository.java
+++ b/src/main/java/com/x1/frans/order/command/domain/repository/DeliveryRepository.java
@@ -1,0 +1,7 @@
+package com.x1.frans.order.command.domain.repository;
+
+import com.x1.frans.order.command.domain.aggregate.Delivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+}

--- a/src/main/java/com/x1/frans/order/command/domain/vo/OrderStatus.java
+++ b/src/main/java/com/x1/frans/order/command/domain/vo/OrderStatus.java
@@ -8,7 +8,6 @@ public enum OrderStatus {
     REVIEWING("검토 중"),
     REVIEW_COMPLETED("검토 완료"),
     APPROVED("결재 완료"),
-    READY_FOR_DELIVERY("배송 준비 중"),
     DELIVERING("배송 중"),
     DELIVERED("배송 완료");
 

--- a/src/main/java/com/x1/frans/user/enums/DeliveryStatus.java
+++ b/src/main/java/com/x1/frans/user/enums/DeliveryStatus.java
@@ -1,9 +1,8 @@
-package com.x1.frans.order.command.domain.vo;
+package com.x1.frans.user.enums;
 
 public enum DeliveryStatus {
 
     UNREGISTERED("미등록"),
-    READY_FOR_DELIVERY("배송 준비 중"),
     DELIVERING("배송 중"),
     DELIVERED("배송 완료"),
     PICKING_UP("반품 수거 중"),


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #103 

## ✅ 작업 사항
- 주문 상태가 결재 완료일 경우에 배송 정보를 최초 등록할 수 있다.
- 배송 정보를 등록하면 배송 상태와 주문 상태가 배송 중 으로 변경 된다.
- 배송 정보를 등록한 후에는 배송 정보를 수정할 수 있다.

---
### 수정 사항
- DeliveryStatus, OrderStatus 의 READY_FOR_DELIVERY("배송 준비 중") 은 필요없다고 판단하여 삭제하였습니다.
  - 결재 완료 후 바로 배송이 진행되는 구조이기 때문. 

## 📸 스크린샷 (선택)

### 배송 정보 입력 전 주문 테이블 (상태 - 결재 완료)
<img width="854" alt="image" src="https://github.com/user-attachments/assets/56d3eb47-8a72-49dc-a3b3-abea2d73696d" />

### 결재 완료 상태에서 배송 정보 입력 시 
<img width="902" alt="image" src="https://github.com/user-attachments/assets/0c92c82d-5ed3-4be1-bed9-6b982401369c" />

### 배송 정보 입력 후 주문 테이블 (상태 - 배송 중)
<img width="881" alt="image" src="https://github.com/user-attachments/assets/93e2fc2f-5f82-41e0-b3c6-ee4d533162ab" />

### 배송 정보 입력 후 배송 테이블
<img width="947" alt="image" src="https://github.com/user-attachments/assets/b5b8e344-2870-4689-9d7c-1f6d983eec94" />

---

### 배송 정보 수정 시
<img width="896" alt="image" src="https://github.com/user-attachments/assets/d4325e4c-daf9-4c71-8b47-d92294508397" />

### 배송 정보 수정 후
<img width="944" alt="image" src="https://github.com/user-attachments/assets/751d914c-f468-4a17-8997-8f13a09603e1" />


## 👩‍💻 공유 포인트 및 논의 사항
- 주문 상태 변경 부분 수정 예정
