### PR TITLE
🚑 fix: 본사용 주문 목록 조회시 권한 누락 수정

### DIFF
--- a/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
+++ b/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
@@ -5,6 +5,8 @@ import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 import com.x1.frans.order.query.service.HqOrderQueryService;
 import com.x1.frans.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,26 +14,35 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/franchise/orders")
 @RequiredArgsConstructor
+@Tag(name = "📝 가맹점 주문 조회", description = "주문 조회 관련 API")
 public class FranchiseOrderQueryController {
 
     private final HqOrderQueryService orderQueryService;
     private final FranchiseOrderQueryMapper franchiseOrderQueryMapper; // userId → franchiseId 조회용
 
     @GetMapping
+    @Operation(
+            summary = "주문 목록 조회",
+            description = "본인이 속한 부서가 관리하는 가맹점의 주문 목록을 조회합니다."
+    )
     public OrderSearchPageResponseDto searchOrdersForFranchise(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @ModelAttribute OrderSearchConditionDto condition
     ) {
         Long userId = Long.valueOf(userDetails.getUserId());
-        Long franchiseId = franchiseOrderQueryMapper.findFranchiseIdByUserId(userId);
+        List<Long> franchiseIds = franchiseOrderQueryMapper.findFranchiseIdsByUserId(userId);
 
         int offset = condition.getSize() * (condition.getPage() - 1);
-        condition.setFranchiseId(franchiseId);
         condition.setOffset(offset);
 
-        return orderQueryService.searchOrders(condition);
+        // ✅ 프랜차이즈 유저는 자신이 소속된 가맹점만 조회하도록 설정
+        condition.setDepartmentFranchiseIds(franchiseIds);
+
+        return orderQueryService.searchOrders(condition, userId);
     }
 }

--- a/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
+++ b/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
@@ -40,7 +40,6 @@ public class FranchiseOrderQueryController {
         int offset = condition.getSize() * (condition.getPage() - 1);
         condition.setOffset(offset);
 
-        // ✅ 프랜차이즈 유저는 자신이 소속된 가맹점만 조회하도록 설정
         condition.setDepartmentFranchiseIds(franchiseIds);
 
         return orderQueryService.searchOrders(condition, userId);

--- a/src/main/java/com/x1/frans/order/query/controller/HqOrderQueryController.java
+++ b/src/main/java/com/x1/frans/order/query/controller/HqOrderQueryController.java
@@ -26,9 +26,11 @@ public class HqOrderQueryController {
             description = "본인이 속한 부서가 관리하는 가맹점의 주문 목록을 조회합니다."
     )
     public OrderSearchPageResponseDto searchOrdersPaged(
-            @ModelAttribute OrderSearchConditionDto condition
+            @ModelAttribute OrderSearchConditionDto condition,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return orderQueryService.searchOrders(condition);
+        Long userId = userDetails.getUserId();
+        return orderQueryService.searchOrders(condition, userId);
     }
 
     @GetMapping("/{orderId}")

--- a/src/main/java/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.java
+++ b/src/main/java/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.java
@@ -1,8 +1,11 @@
 package com.x1.frans.order.query.dao;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface FranchiseOrderQueryMapper {
-    Long findFranchiseIdByUserId(Long userId);
+    List<Long> findFranchiseIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -19,4 +21,6 @@ public class OrderSearchConditionDto {
     private int page;
     private int size;           // 한 페이지당 목록 개수
     private int offset;         // size * (page -1)
+
+    private List<Long> departmentFranchiseIds; // 권한 필터링
 }

--- a/src/main/java/com/x1/frans/order/query/service/HqOrderQueryService.java
+++ b/src/main/java/com/x1/frans/order/query/service/HqOrderQueryService.java
@@ -5,7 +5,7 @@ import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 
 public interface HqOrderQueryService {
-    OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition);
+    OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition, Long userId);
 
     OrderDetailDto getOrderDetail(Long orderId, Long userId);
 }

--- a/src/main/java/com/x1/frans/order/query/service/HqOrderQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/query/service/HqOrderQueryServiceImpl.java
@@ -29,9 +29,8 @@ public class HqOrderQueryServiceImpl implements HqOrderQueryService {
     @Transactional
     public OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition, Long userId) {
 
-        // ✅ franchiseId가 null이면 HQ 유저, null 아니면 프랜차이즈 유저로 간주
+        // franchiseId가 null이면 HQ 유저, null 아니면 프랜차이즈 유저
         if (condition.getDepartmentFranchiseIds() == null || condition.getDepartmentFranchiseIds().isEmpty()) {
-            // 👉 HQ 유저만 접근 가능한 경우
             List<Long> allowedFranchiseIds = userQueryService.getAccessibleFranchiseIdsForUser(userId);
             condition.setDepartmentFranchiseIds(allowedFranchiseIds);
         }

--- a/src/main/java/com/x1/frans/order/query/service/HqOrderQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/query/service/HqOrderQueryServiceImpl.java
@@ -8,6 +8,7 @@ import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
 import com.x1.frans.product.query.dto.ProductDetailDTO;
+import com.x1.frans.user.query.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,9 +23,18 @@ public class HqOrderQueryServiceImpl implements HqOrderQueryService {
 
     private final HqOrderQueryMapper orderQueryMapper;
     private final OrderAuthorizationService orderAuthorizationService;
+    private final UserQueryService userQueryService;
 
     @Override
-    public OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition) {
+    @Transactional
+    public OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition, Long userId) {
+
+        // ✅ franchiseId가 null이면 HQ 유저, null 아니면 프랜차이즈 유저로 간주
+        if (condition.getDepartmentFranchiseIds() == null || condition.getDepartmentFranchiseIds().isEmpty()) {
+            // 👉 HQ 유저만 접근 가능한 경우
+            List<Long> allowedFranchiseIds = userQueryService.getAccessibleFranchiseIdsForUser(userId);
+            condition.setDepartmentFranchiseIds(allowedFranchiseIds);
+        }
 
         // 페이지 오프셋 계산
         int offset = (condition.getPage() - 1) * condition.getSize();
@@ -45,6 +55,7 @@ public class HqOrderQueryServiceImpl implements HqOrderQueryService {
                 .hasPrevious(condition.getPage() > 1)
                 .build();
     }
+
 
     @Override
     @Transactional

--- a/src/main/java/com/x1/frans/user/command/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/x1/frans/user/command/service/UserCommandServiceImpl.java
@@ -2,7 +2,9 @@ package com.x1.frans.user.command.service;
 
 import com.x1.frans.email.dto.UserCredentialsDTO;
 import com.x1.frans.email.service.EmailService;
-import com.x1.frans.exception.*;
+import com.x1.frans.exception.DuplicationException;
+import com.x1.frans.exception.InvalidAddressException;
+import com.x1.frans.exception.InvalidUserTypeException;
 import com.x1.frans.franchise.command.domain.aggregate.FranchiseEntity;
 import com.x1.frans.franchise.command.domain.repository.FranchiseCommandRepository;
 import com.x1.frans.franchise.query.service.FranchiseQueryService;
@@ -21,7 +23,7 @@ import com.x1.frans.user.common.SeoulDistrictCode;
 import com.x1.frans.user.enums.UserType;
 import com.x1.frans.user.query.service.UserQueryService;
 import com.x1.frans.user.util.GenerateRandomPassword;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +33,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Service
+@RequiredArgsConstructor
 public class UserCommandServiceImpl implements UserCommandService {
 
     private final UserCommandRepository userCommandRepository;
@@ -42,27 +45,6 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final FranchiseQueryService franchiseQueryService;
     private final SupplierCommandRepository supplierCommandRepository;
     private final SupplierQueryService supplierQueryService;
-
-    @Autowired
-    public UserCommandServiceImpl(UserCommandRepository userRepository,
-                                  BCryptPasswordEncoder bCryptPasswordEncoder,
-                                  HqUserDetailCommandRepository hqUserDetailRepository,
-                                  FranchiseCommandRepository franchiseCommandRepository,
-                                  SupplierCommandRepository supplierCommandRepository,
-                                  FranchiseQueryService franchiseQueryService,
-                                  SupplierQueryService supplierQueryService,
-                                  EmailService emailService,
-                                  UserQueryService userQueryService) {
-        this.userCommandRepository = userRepository;
-        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
-        this.hqUserDetailCommandRepository = hqUserDetailRepository;
-        this.emailService = emailService;
-        this.userQueryService = userQueryService;
-        this.franchiseCommandRepository = franchiseCommandRepository;
-        this.franchiseQueryService = franchiseQueryService;
-        this.supplierCommandRepository = supplierCommandRepository;
-        this.supplierQueryService = supplierQueryService;
-    }
 
     /**
      * 본사(HQ) 사용자 계정을 생성
@@ -130,10 +112,10 @@ public class UserCommandServiceImpl implements UserCommandService {
     /**
      * 전화번호, 이메일, 사용자 타입이 유효한지 확인
      *
-     * @param phone 사용자 전화번호
-     * @param email 사용자 이메일
+     * @param phone    사용자 전화번호
+     * @param email    사용자 이메일
      * @param userType 사용자 타입 문자열 (ADMIN, HQ, FRANCHISE, SUPPLIER 중 하나)
-     * @throws DuplicationException 전화번호 또는 이메일 중복 시
+     * @throws DuplicationException     전화번호 또는 이메일 중복 시
      * @throws InvalidUserTypeException 유효하지 않은 사용자 타입일 경우
      */
     private void validateUserCredentials(String phone, String email, String userType) {
@@ -160,7 +142,7 @@ public class UserCommandServiceImpl implements UserCommandService {
      * HqUserDetailEntity를 생성하여 값들을 설정
      *
      * @param savedUser 생성된 사용자
-     * @param vo 본사 사용자 요청 VO
+     * @param vo        본사 사용자 요청 VO
      * @return 설정된 HqUserDetailEntity
      */
     private HqUserDetailEntity buildHqUserDetail(UserEntity savedUser, HqUserRequestVO vo) {
@@ -176,7 +158,7 @@ public class UserCommandServiceImpl implements UserCommandService {
      * FranchiseEntity를 생성하여 값들을 설정
      *
      * @param savedUser 가맹점 대표 사용자
-     * @param vo 가맹점 요청 정보
+     * @param vo        가맹점 요청 정보
      * @return 설정된 FranchiseEntity
      */
     private FranchiseEntity buildFranchise(UserEntity savedUser, FranchiseUserRequestVO vo) {
@@ -200,7 +182,7 @@ public class UserCommandServiceImpl implements UserCommandService {
      * SupplierEntity를 생성하여 값들을 설정
      *
      * @param savedUser 공급처 사용자
-     * @param vo 공급처 요청 정보
+     * @param vo        공급처 요청 정보
      * @return 설정된 SupplierEntity
      */
     private SupplierEntity buildSupplier(UserEntity savedUser, SupplierUserRequestVO vo) {
@@ -222,7 +204,8 @@ public class UserCommandServiceImpl implements UserCommandService {
         return supplier;
     }
 
-    private record UserCodeAndRawPw(String userCode, String rawPassword) {}
+    private record UserCodeAndRawPw(String userCode, String rawPassword) {
+    }
 
     /**
      * 사용자 코드와 랜덤 비밀번호를 생성
@@ -238,7 +221,8 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     /**
      * 비밀번호 암호화 후 user 저장
-     * @param vo 사용자 생성 요청 데이터
+     *
+     * @param vo               사용자 생성 요청 데이터
      * @param userCodeAndRawPw 생성된 사용자 코드와 평문 비밀번호
      * @return UserEntity
      */
@@ -251,7 +235,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     /**
      * 사용자에게 계정 정보(아이디, 초기 비밀번호)를 이메일로 발송
      *
-     * @param vo 사용자 요청 정보
+     * @param vo               사용자 요청 정보
      * @param userCodeAndRawPw 사용자 코드와 평문 비밀번호
      */
     private void sendUserEmail(CreateUserRequestVO vo, UserCodeAndRawPw userCodeAndRawPw) {
@@ -307,7 +291,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     /**
      * 새로운 가맹점 코드 생성
      *
-     * @param address 주소 정보
+     * @param address  주소 정보
      * @param signedAt 계약 일자
      */
     private String createNewFranchiseCode(String address, LocalDate signedAt) {
@@ -359,7 +343,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Transactional
     @Override
     public void accountLock(String userCode) {
-        
+
         userCommandRepository.accountLock(userCode);
     }
 }

--- a/src/main/java/com/x1/frans/user/query/repository/UserQueryMapper.java
+++ b/src/main/java/com/x1/frans/user/query/repository/UserQueryMapper.java
@@ -26,4 +26,6 @@ public interface UserQueryMapper {
     List<SearchSupplierUserDTO> findSupplierUser(@Param("name") String name);
 
     HqUserDepartmentDTO getDepartmentInfo(@Param("userId") Long userId);
+
+    List<Long> findFranchiseIdsByDepartmentId(Long departmentId);
 }

--- a/src/main/java/com/x1/frans/user/query/service/UserQueryService.java
+++ b/src/main/java/com/x1/frans/user/query/service/UserQueryService.java
@@ -23,4 +23,6 @@ public interface UserQueryService extends UserDetailsService {
     List<SearchSupplierUserDTO> findSupplierUser(String name);
 
     HqUserDepartmentDTO getDepartmentInfo(Long userId);
+
+    List<Long> getAccessibleFranchiseIdsForUser(Long userId);
 }

--- a/src/main/java/com/x1/frans/user/query/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/user/query/service/UserQueryServiceImpl.java
@@ -1,12 +1,12 @@
 package com.x1.frans.user.query.service;
 
+import com.x1.frans.exception.UnauthorizedAccessException;
 import com.x1.frans.security.CustomUserDetails;
 import com.x1.frans.security.exception.AccountDeletedException;
 import com.x1.frans.security.exception.AccountLockedException;
-import com.x1.frans.user.command.aggregate.UserEntity;
 import com.x1.frans.user.query.dto.*;
 import com.x1.frans.user.query.repository.UserQueryMapper;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -16,14 +16,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class UserQueryServiceImpl implements UserQueryService {
 
     private final UserQueryMapper userQueryMapper;
-
-    @Autowired
-    public UserQueryServiceImpl(UserQueryMapper userQueryMapper) {
-        this.userQueryMapper = userQueryMapper;
-    }
 
     @Override
     public String findLatestUserCode(String userType, String codePrefix) {
@@ -85,4 +81,15 @@ public class UserQueryServiceImpl implements UserQueryService {
 
         return userQueryMapper.getDepartmentInfo(userId);
     }
+
+    @Override
+    public List<Long> getAccessibleFranchiseIdsForUser(Long userId) {
+        HqUserDepartmentDTO dept = getDepartmentInfo(userId);
+        if (dept == null || dept.getDepartmentId() == null) {
+            throw new UnauthorizedAccessException("해당 사용자의 부서 정보를 찾을 수 없습니다.");
+        }
+
+        return userQueryMapper.findFranchiseIdsByDepartmentId(dept.getDepartmentId());
+    }
+
 }

--- a/src/main/resources/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.xml
@@ -5,10 +5,10 @@
 
 <mapper namespace="com.x1.frans.order.query.dao.FranchiseOrderQueryMapper">
 
-    <select id="findFranchiseIdByUserId" resultType="long">
+    <select id="findFranchiseIdsByUserId" parameterType="long" resultType="long">
         SELECT id
-        FROM franchise
-        WHERE owner_id = #{userId}
+          FROM franchise
+         WHERE owner_id = #{userId}
     </select>
 
 </mapper>

--- a/src/main/resources/com/x1/frans/order/query/dao/HqOrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/HqOrderQueryMapper.xml
@@ -31,8 +31,25 @@
           JOIN product_order po ON o.id = po.order_id
           JOIN product p ON po.product_id = p.id
         <where>
-            <if test="franchiseId != null">
-                o.franchise_id = #{franchiseId}
+            <!-- 권한 필터링 -->
+            <if test="departmentFranchiseIds != null and departmentFranchiseIds.size() > 0">
+                <choose>
+                    <!-- franchiseId가 있을 경우, departmentFranchiseIds 안에 포함된 경우만 허용 -->
+                    <when test="franchiseId != null">
+                        o.franchise_id = #{franchiseId}
+                        AND #{franchiseId} IN
+                        <foreach item="id" collection="departmentFranchiseIds" open="(" separator="," close=")">
+                            #{id}
+                        </foreach>
+                    </when>
+                    <!-- franchiseId가 없으면 전체 허용된 목록으로 필터링 -->
+                    <otherwise>
+                        o.franchise_id IN
+                        <foreach item="id" collection="departmentFranchiseIds" open="(" separator="," close=")">
+                            #{id}
+                        </foreach>
+                    </otherwise>
+                </choose>
             </if>
 
             <if test="code != null and code != ''">
@@ -64,8 +81,23 @@
           JOIN product_order po ON o.id = po.order_id
           JOIN product p ON po.product_id = p.id
         <where>
-            <if test="franchiseId != null">
-                o.franchise_id = #{franchiseId}
+            <!-- 권한 필터링 -->
+            <if test="departmentFranchiseIds != null and departmentFranchiseIds.size() > 0">
+                <choose>
+                    <when test="franchiseId != null">
+                        o.franchise_id = #{franchiseId}
+                        AND #{franchiseId} IN
+                        <foreach item="id" collection="departmentFranchiseIds" open="(" separator="," close=")">
+                            #{id}
+                        </foreach>
+                    </when>
+                    <otherwise>
+                        o.franchise_id IN
+                        <foreach item="id" collection="departmentFranchiseIds" open="(" separator="," close=")">
+                            #{id}
+                        </foreach>
+                    </otherwise>
+                </choose>
             </if>
 
             <if test="code != null and code != ''">

--- a/src/main/resources/com/x1/frans/user/query/repository/UserQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/user/query/repository/UserQueryMapper.xml
@@ -163,4 +163,10 @@
           LEFT JOIN `department` c ON b.`department_id` = c.`id`
          WHERE a.`id` = #{userId}
     </select>
+
+    <select id="findFranchiseIdsByDepartmentId" resultType="long">
+        SELECT id FROM franchise
+         WHERE department_id = #{departmentId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #111 

## ✅ 작업 사항
- 본사 직원이 가맹점에 대한 주문 목록 조회시 본인이 담당하는 가맹점 외에 다른 가맹점도 조회가 되는 오류를 수정
- 본인이 소속된 부서가 담당하는 가맹점인지 권한 체크하는 로직이 누락되어 추가

## 📸 스크린샷 (선택)
<br>

## 👩‍💻 공유 포인트 및 논의 사항
