### PR TITLE
🚑 fix: 주문 취소 수정, 본사용 주문 목록 조회 조건 수정

### DIFF
--- a/src/main/java/com/x1/frans/order/command/application/service/FranchiseOrderCommandServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/command/application/service/FranchiseOrderCommandServiceImpl.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -93,12 +92,6 @@ public class FranchiseOrderCommandServiceImpl implements FranchiseOrderCommandSe
                     .build();
 
             productOrders.add(productOrder);
-
-            System.out.println(">> 자재명: " + product.getName());
-            System.out.println(">> 단가: " + product.getSalePrice());
-            System.out.println(">> 수량: " + quantity);
-            System.out.println(">> 소계: " + unitPrice.multiply(BigDecimal.valueOf(quantity)));
-            System.out.println(">> 누적금액: " + totalAmount.add(unitPrice.multiply(BigDecimal.valueOf(quantity))));
         }
 
 
@@ -121,7 +114,7 @@ public class FranchiseOrderCommandServiceImpl implements FranchiseOrderCommandSe
         StoreOrderDeadline deadline = deadlineRepository.findById(1L)
                 .orElseThrow(() -> new OrderDeadlineTimeNotFoundException("주문 마감 시간이 설정되어 있지 않습니다."));
 
-        order.cancelByFranchise(LocalTime.now(), deadline.getOrderDeadlineAt());
+        order.cancelByFranchise(deadline.getOrderDeadlineAt());
 
         orderCommandRepository.save(order);
     }

--- a/src/main/java/com/x1/frans/order/command/application/util/OrderDeadlineUtils.java
+++ b/src/main/java/com/x1/frans/order/command/application/util/OrderDeadlineUtils.java
@@ -1,0 +1,19 @@
+package com.x1.frans.order.command.application.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class OrderDeadlineUtils {
+    public static LocalDate calculateProcessingDate(LocalDateTime orderTime, LocalTime deadlineTime) {
+        return orderTime.toLocalTime().isAfter(deadlineTime)
+                ? orderTime.toLocalDate().plusDays(1)
+                : orderTime.toLocalDate();
+    }
+
+    public static boolean canCancelOrder(LocalDateTime orderCreatedAt, LocalTime deadlineTime, LocalDateTime currentTime) {
+        LocalDate processingDate = calculateProcessingDate(orderCreatedAt, deadlineTime);
+        LocalDateTime processingDeadline = processingDate.atTime(deadlineTime);
+        return currentTime.isBefore(processingDeadline);
+    }
+}

--- a/src/main/java/com/x1/frans/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/x1/frans/order/command/domain/aggregate/Order.java
@@ -3,6 +3,7 @@ package com.x1.frans.order.command.domain.aggregate;
 import com.x1.frans.exception.InvalidRejectConditionException;
 import com.x1.frans.exception.OrderRejectReasonRequiredException;
 import com.x1.frans.franchise.command.domain.aggregate.FranchiseEntity;
+import com.x1.frans.order.command.application.util.OrderDeadlineUtils;
 import com.x1.frans.order.command.domain.vo.OrderStatus;
 import com.x1.frans.user.command.aggregate.UserEntity;
 import jakarta.persistence.*;
@@ -121,12 +122,12 @@ public class Order {
         this.delivery = delivery;
     }
 
-    public void cancelByFranchise(LocalTime currentTime, LocalTime deadlineTime) {
+    public void cancelByFranchise(LocalTime deadlineTime) {
         if (this.status != OrderStatus.WAITING_FOR_RECEIPT) {
             throw new InvalidRejectConditionException("접수 대기 상태에서만 취소할 수 있습니다.");
         }
 
-        if (currentTime.isAfter(deadlineTime)) {
+        if (!OrderDeadlineUtils.canCancelOrder(this.createdAt, deadlineTime, LocalDateTime.now())) {
             throw new InvalidRejectConditionException("주문 마감 시간 이후에는 취소할 수 없습니다.");
         }
 

--- a/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
+++ b/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
@@ -1,9 +1,8 @@
 package com.x1.frans.order.query.controller;
 
-import com.x1.frans.order.query.dao.FranchiseOrderQueryMapper;
 import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
-import com.x1.frans.order.query.service.HqOrderQueryService;
+import com.x1.frans.order.query.service.FranchiseOrderQueryService;
 import com.x1.frans.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,34 +13,21 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/franchise/orders")
 @RequiredArgsConstructor
 @Tag(name = "📝 가맹점 주문 조회", description = "주문 조회 관련 API")
 public class FranchiseOrderQueryController {
 
-    private final HqOrderQueryService orderQueryService;
-    private final FranchiseOrderQueryMapper franchiseOrderQueryMapper; // userId → franchiseId 조회용
+    private final FranchiseOrderQueryService franchiseOrderQueryService;
 
     @GetMapping
-    @Operation(
-            summary = "주문 목록 조회",
-            description = "본인이 속한 부서가 관리하는 가맹점의 주문 목록을 조회합니다."
-    )
-    public OrderSearchPageResponseDto searchOrdersForFranchise(
+    @Operation(summary = "주문 목록 조회", description = "가맹점 유저가 자신의 주문 목록을 조회합니다.")
+    public OrderSearchPageResponseDto searchOrders(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @ModelAttribute OrderSearchConditionDto condition
-    ) {
-        Long userId = Long.valueOf(userDetails.getUserId());
-        List<Long> franchiseIds = franchiseOrderQueryMapper.findFranchiseIdsByUserId(userId);
+            @ModelAttribute OrderSearchConditionDto condition) {
 
-        int offset = condition.getSize() * (condition.getPage() - 1);
-        condition.setOffset(offset);
-
-        condition.setDepartmentFranchiseIds(franchiseIds);
-
-        return orderQueryService.searchOrders(condition, userId);
+        Long userId = userDetails.getUserId();
+        return franchiseOrderQueryService.searchOrders(condition, userId);
     }
 }

--- a/src/main/java/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.java
+++ b/src/main/java/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.java
@@ -1,11 +1,16 @@
 package com.x1.frans.order.query.dao;
 
+import com.x1.frans.order.query.dto.OrderSearchConditionDto;
+import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface FranchiseOrderQueryMapper {
-    List<Long> findFranchiseIdsByUserId(@Param("userId") Long userId);
+    // 목록 조회 (LIMIT, OFFSET 적용)
+    List<OrderSummaryResponseDto> searchOrders(OrderSearchConditionDto condition);
+
+    // 전체 개수 조회 (페이징 계산용)
+    int countOrders(OrderSearchConditionDto condition);
 }

--- a/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
@@ -4,15 +4,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
-
 @Getter
 @Setter
 @NoArgsConstructor
 public class OrderSearchConditionDto {
     private Long franchiseId;
-    private String filterType;
-    private String keyword;
+    private Long userId;
+    private Long ownerId;
     private String code;
     private String product;
     private String status;
@@ -21,6 +19,4 @@ public class OrderSearchConditionDto {
     private int page;
     private int size;           // 한 페이지당 목록 개수
     private int offset;         // size * (page -1)
-
-    private List<Long> departmentFranchiseIds; // 권한 필터링
 }

--- a/src/main/java/com/x1/frans/order/query/service/FranchiseOrderQueryService.java
+++ b/src/main/java/com/x1/frans/order/query/service/FranchiseOrderQueryService.java
@@ -1,0 +1,8 @@
+package com.x1.frans.order.query.service;
+
+import com.x1.frans.order.query.dto.OrderSearchConditionDto;
+import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
+
+public interface FranchiseOrderQueryService {
+    OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition, Long userId);
+}

--- a/src/main/java/com/x1/frans/order/query/service/FranchiseOrderQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/query/service/FranchiseOrderQueryServiceImpl.java
@@ -1,0 +1,42 @@
+package com.x1.frans.order.query.service;
+
+import com.x1.frans.order.query.dao.FranchiseOrderQueryMapper;
+import com.x1.frans.order.query.dto.OrderSearchConditionDto;
+import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
+import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FranchiseOrderQueryServiceImpl implements FranchiseOrderQueryService {
+
+    private final FranchiseOrderQueryMapper franchiseOrderQueryMapper;
+
+    @Override
+    @Transactional
+    public OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition, Long userId) {
+        condition.setOwnerId(userId);
+
+        int offset = (condition.getPage() - 1) * condition.getSize();
+        condition.setOffset(offset);
+
+        List<OrderSummaryResponseDto> content = franchiseOrderQueryMapper.searchOrders(condition);
+        int totalCount = franchiseOrderQueryMapper.countOrders(condition);
+        int totalPages = (int) Math.ceil((double) totalCount / condition.getSize());
+
+        return OrderSearchPageResponseDto.builder()
+                .content(content)
+                .totalCount(totalCount)
+                .page(condition.getPage())
+                .size(condition.getSize())
+                .totalPages(totalPages)
+                .hasNext(condition.getPage() < totalPages)
+                .hasPrevious(condition.getPage() > 1)
+                .build();
+    }
+
+}

--- a/src/main/java/com/x1/frans/order/query/service/HqOrderQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/query/service/HqOrderQueryServiceImpl.java
@@ -7,15 +7,14 @@ import com.x1.frans.order.query.dto.OrderDetailDto;
 import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
+import com.x1.frans.order.query.service.support.OrderDetailCalculator;
+import com.x1.frans.order.query.service.support.OrderQuerySupport;
 import com.x1.frans.product.query.dto.ProductDetailDTO;
-import com.x1.frans.user.query.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,72 +22,44 @@ public class HqOrderQueryServiceImpl implements HqOrderQueryService {
 
     private final HqOrderQueryMapper orderQueryMapper;
     private final OrderAuthorizationService orderAuthorizationService;
-    private final UserQueryService userQueryService;
+    private final OrderQuerySupport orderQuerySupport;
+    private final OrderDetailCalculator orderDetailCalculator;
 
     @Override
     @Transactional
     public OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition, Long userId) {
+        condition.setUserId(userId);
 
-        // franchiseId가 null이면 HQ 유저, null 아니면 프랜차이즈 유저
-        if (condition.getDepartmentFranchiseIds() == null || condition.getDepartmentFranchiseIds().isEmpty()) {
-            List<Long> allowedFranchiseIds = userQueryService.getAccessibleFranchiseIdsForUser(userId);
-            condition.setDepartmentFranchiseIds(allowedFranchiseIds);
-        }
-
-        // 페이지 오프셋 계산
-        int offset = (condition.getPage() - 1) * condition.getSize();
-        condition.setOffset(offset);
-
-        // 주문 목록 및 총 개수 조회
+        orderQuerySupport.applyPagination(condition);
         List<OrderSummaryResponseDto> content = orderQueryMapper.searchOrders(condition);
         int totalCount = orderQueryMapper.countOrders(condition);
-        int totalPages = (int) Math.ceil((double) totalCount / condition.getSize());
 
-        return OrderSearchPageResponseDto.builder()
-                .content(content)
-                .totalCount(totalCount)
-                .page(condition.getPage())
-                .size(condition.getSize())
-                .totalPages(totalPages)
-                .hasNext(condition.getPage() < totalPages)
-                .hasPrevious(condition.getPage() > 1)
-                .build();
+        return orderQuerySupport.buildPagedResponse(condition, content, totalCount);
     }
-
 
     @Override
     @Transactional
     public OrderDetailDto getOrderDetail(Long orderId, Long userId) {
-        // 권한 검증 및 주문 조회
-        orderAuthorizationService.getAuthorizedOrder(orderId, userId);
+        validateOrderAccess(orderId, userId);
+        OrderDetailDto detail = fetchOrderDetail(orderId);
+        List<ProductDetailDTO> products = fetchProductDetails(orderId);
+        orderDetailCalculator.fillDetails(detail, products);
+        return detail;
+    }
 
-        // 상세 정보 조회
+    private void validateOrderAccess(Long orderId, Long userId) {
+        orderAuthorizationService.getAuthorizedOrder(orderId, userId);
+    }
+
+    private OrderDetailDto fetchOrderDetail(Long orderId) {
         OrderDetailDto detail = orderQueryMapper.findOrderDetailById(orderId);
         if (detail == null) {
             throw new OrderNotFoundException("주문 상세 정보를 찾을 수 없습니다.");
         }
-
-        // 상품 목록 조회
-        List<ProductDetailDTO> products = orderQueryMapper.findProductsByOrderId(orderId);
-        detail.setProducts(products);
-
-        // 총 수량 계산
-        int totalQty = products.stream()
-                .mapToInt(p -> Optional.ofNullable(p.getQuantity()).orElse(0))
-                .sum();
-        detail.setTotalQuantity(totalQty);
-
-        // 총 금액 계산
-        BigDecimal totalAmount = products.stream()
-                .map(p -> {
-                    BigDecimal price = Optional.ofNullable(p.getSalePrice()).orElse(BigDecimal.ZERO);
-                    int qty = Optional.ofNullable(p.getQuantity()).orElse(0);
-                    return price.multiply(BigDecimal.valueOf(qty));
-                })
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-        detail.setTotalAmount(totalAmount);
-
         return detail;
     }
 
+    private List<ProductDetailDTO> fetchProductDetails(Long orderId) {
+        return orderQueryMapper.findProductsByOrderId(orderId);
+    }
 }

--- a/src/main/java/com/x1/frans/order/query/service/support/FranchiseAccessSupport.java
+++ b/src/main/java/com/x1/frans/order/query/service/support/FranchiseAccessSupport.java
@@ -1,0 +1,20 @@
+package com.x1.frans.order.query.service.support;
+
+import com.x1.frans.user.query.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class FranchiseAccessSupport {
+    private final UserQueryService userQueryService;
+
+    public List<Long> getAccessibleFranchisesOrThrow(Long userId, List<Long> FranchiseIds) {
+        if (FranchiseIds == null || FranchiseIds.isEmpty()) {
+            return userQueryService.getAccessibleFranchiseIdsForUser(userId);
+        }
+        return FranchiseIds;
+    }
+}

--- a/src/main/java/com/x1/frans/order/query/service/support/OrderDetailCalculator.java
+++ b/src/main/java/com/x1/frans/order/query/service/support/OrderDetailCalculator.java
@@ -1,0 +1,38 @@
+package com.x1.frans.order.query.service.support;
+
+import com.x1.frans.order.query.dto.OrderDetailDto;
+import com.x1.frans.product.query.dto.ProductDetailDTO;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Component
+public class OrderDetailCalculator {
+
+    public void fillDetails(OrderDetailDto detail, List<ProductDetailDTO> products) {
+        detail.setProducts(products);
+        detail.setTotalQuantity(calculateTotalQuantity(products));
+        detail.setTotalAmount(calculateTotalAmount(products));
+    }
+
+    // 총 수량 계산
+    private int calculateTotalQuantity(List<ProductDetailDTO> products) {
+        int totalQty = 0;
+        for (ProductDetailDTO p : products) {
+            totalQty += p.getQuantity();
+        }
+        return totalQty;
+    }
+
+    // 총 금액 계산
+    private BigDecimal calculateTotalAmount(List<ProductDetailDTO> products) {
+        BigDecimal totalAmount = BigDecimal.ZERO;
+        for (ProductDetailDTO p : products) {
+            BigDecimal price = p.getSalePrice();
+            int qty = p.getQuantity();
+            totalAmount = totalAmount.add(price.multiply(BigDecimal.valueOf(qty)));
+        }
+        return totalAmount;
+    }
+}

--- a/src/main/java/com/x1/frans/order/query/service/support/OrderQuerySupport.java
+++ b/src/main/java/com/x1/frans/order/query/service/support/OrderQuerySupport.java
@@ -1,0 +1,36 @@
+package com.x1.frans.order.query.service.support;
+
+import com.x1.frans.order.query.dto.OrderSearchConditionDto;
+import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
+import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class OrderQuerySupport {
+
+    public void applyPagination(OrderSearchConditionDto condition) {
+        int offset = (condition.getPage() - 1) * condition.getSize();
+        condition.setOffset(offset);
+    }
+
+    public OrderSearchPageResponseDto buildPagedResponse(
+            OrderSearchConditionDto condition,
+            List<OrderSummaryResponseDto> content,
+            int totalCount
+    ) {
+        int totalPages = (int) Math.ceil((double) totalCount / condition.getSize());
+
+        return OrderSearchPageResponseDto.builder()
+                .content(content)
+                .totalCount(totalCount)
+                .page(condition.getPage())
+                .size(condition.getSize())
+                .totalPages(totalPages)
+                .hasNext(condition.getPage() < totalPages)
+                .hasPrevious(condition.getPage() > 1)
+                .build();
+    }
+
+}

--- a/src/main/resources/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.xml
@@ -5,10 +5,84 @@
 
 <mapper namespace="com.x1.frans.order.query.dao.FranchiseOrderQueryMapper">
 
-    <select id="findFranchiseIdsByUserId" parameterType="long" resultType="long">
-        SELECT id
-          FROM franchise
-         WHERE owner_id = #{userId}
+    <resultMap id="OrderSummaryMap" type="com.x1.frans.order.query.dto.OrderSummaryResponseDto">
+        <id property="orderId" column="order_id"/>
+        <result property="orderCode" column="order_code"/>
+        <result property="productSummary" column="product_summary"/>
+        <result property="status" column="status"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="totalAmount" column="total_amount"/>
+        <result property="franchiseName" column="franchise_name"/>
+    </resultMap>
+
+    <select id="searchOrders" resultMap="OrderSummaryMap"
+            parameterType="com.x1.frans.order.query.dto.OrderSearchConditionDto">
+        SELECT
+               o.id AS order_id,
+               o.code AS order_code,
+               CONCAT(p.name, ' 외 ', COUNT(*) - 1, '건') AS product_summary,
+               o.status,
+               o.created_at,
+               o.total_amount,
+               f.name AS franchise_name
+          FROM orders o
+          JOIN franchise f ON o.franchise_id = f.id
+          JOIN product_order po ON o.id = po.order_id
+          JOIN product p ON po.product_id = p.id
+        <where>
+            <if test="ownerId != null">
+                o.franchise_id IN (
+                SELECT id
+                  FROM franchise
+                 WHERE owner_id = #{ownerId}
+                )
+            </if>
+            <if test="code != null and code != ''">
+                AND o.code LIKE CONCAT('%', #{code}, '%')
+            </if>
+            <if test="product != null and product != ''">
+                AND p.name LIKE CONCAT('%', #{product}, '%')
+            </if>
+            <if test="status != null and status != ''">
+                AND o.status LIKE CONCAT('%', #{status}, '%')
+            </if>
+            <if test="startDate != null and endDate != null">
+                AND DATE(o.created_at) BETWEEN #{startDate} AND #{endDate}
+            </if>
+        </where>
+         GROUP BY o.id
+         ORDER BY o.created_at DESC
+         LIMIT #{size} OFFSET #{offset}
+    </select>
+
+
+    <select id="countOrders" resultType="int"
+            parameterType="com.x1.frans.order.query.dto.OrderSearchConditionDto">
+        SELECT COUNT(DISTINCT o.id)
+          FROM orders o
+          JOIN product_order po ON o.id = po.order_id
+          JOIN product p ON po.product_id = p.id
+        <where>
+            <if test="ownerId != null">
+                o.franchise_id IN (
+                SELECT id
+                  FROM franchise
+                 WHERE owner_id = #{ownerId}
+                )
+            </if>
+            <if test="code != null and code != ''">
+                AND o.code LIKE CONCAT('%', #{code}, '%')
+            </if>
+            <if test="product != null and product != ''">
+                AND p.name LIKE CONCAT('%', #{product}, '%')
+            </if>
+            <if test="status != null and status != ''">
+                AND o.status LIKE CONCAT('%', #{status}, '%')
+            </if>
+            <if test="startDate != null and endDate != null">
+                AND DATE(o.created_at) BETWEEN #{startDate} AND #{endDate}
+            </if>
+        </where>
     </select>
 
 </mapper>

--- a/src/main/resources/com/x1/frans/order/query/dao/HqOrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/HqOrderQueryMapper.xml
@@ -21,35 +21,35 @@
         SELECT
                o.id AS order_id
              , o.code AS order_code
-             , CONCAT(p.name, ' 외 ', COUNT(*) - 1, '건') AS product_summary
+             , CASE
+               WHEN COUNT(DISTINCT po.product_id) > 1
+               THEN CONCAT(MIN(p.name), ' 외 ', COUNT(DISTINCT po.product_id) - 1, '건')
+               ELSE MIN(p.name)
+               END AS product_summary
              , o.status
              , o.created_at
              , o.total_amount
              , f.name AS franchise_name
           FROM orders o
           JOIN franchise f ON o.franchise_id = f.id
+          LEFT JOIN hq_user_detail h ON f.department_id = h.department_id
           JOIN product_order po ON o.id = po.order_id
           JOIN product p ON po.product_id = p.id
         <where>
-            <!-- 권한 필터링 -->
-            <if test="departmentFranchiseIds != null and departmentFranchiseIds.size() > 0">
-                <choose>
-                    <!-- franchiseId가 있을 경우, departmentFranchiseIds 안에 포함된 경우만 허용 -->
-                    <when test="franchiseId != null">
-                        o.franchise_id = #{franchiseId}
-                        AND #{franchiseId} IN
-                        <foreach item="id" collection="departmentFranchiseIds" open="(" separator="," close=")">
-                            #{id}
-                        </foreach>
-                    </when>
-                    <!-- franchiseId가 없으면 전체 허용된 목록으로 필터링 -->
-                    <otherwise>
-                        o.franchise_id IN
-                        <foreach item="id" collection="departmentFranchiseIds" open="(" separator="," close=")">
-                            #{id}
-                        </foreach>
-                    </otherwise>
-                </choose>
+            <!-- WAITING_FOR_RECEIPT 상태는 항상 제외 -->
+            o.status != 'WAITING_FOR_RECEIPT'
+
+            <!-- 추가 상태 필터 있을 경우 -->
+            <if test="status != null and status.trim() != '' and status != 'WAITING_FOR_RECEIPT'">
+                AND o.status = #{status}
+            </if>
+
+            <if test="userId != null">
+                AND h.user_id = #{userId}
+            </if>
+
+            <if test="franchiseId != null">
+                AND o.franchise_id = #{franchiseId}
             </if>
 
             <if test="code != null and code != ''">
@@ -57,20 +57,21 @@
             </if>
 
             <if test="product != null and product != ''">
-                AND p.name LIKE CONCAT('%', #{product}, '%')
-            </if>
-
-            <if test="status != null and status != ''">
-                AND o.status LIKE CONCAT('%', #{status}, '%')
+                AND EXISTS (
+                SELECT 1 FROM product_order po2
+                JOIN product p2 ON po2.product_id = p2.id
+                WHERE po2.order_id = o.id
+                AND p2.name LIKE CONCAT('%', #{product}, '%')
+                )
             </if>
 
             <if test="startDate != null and endDate != null">
                 AND DATE(o.created_at) BETWEEN #{startDate} AND #{endDate}
             </if>
         </where>
-          GROUP BY o.id
-          ORDER BY o.created_at DESC
-          LIMIT #{size} OFFSET #{offset}
+         GROUP BY o.id, o.code, o.status, o.created_at, o.total_amount, f.name
+         ORDER BY o.created_at DESC
+         LIMIT #{size} OFFSET #{offset}
     </select>
 
     <!-- 주문 개수 조회 (페이징 계산용) -->
@@ -78,26 +79,23 @@
             parameterType="com.x1.frans.order.query.dto.OrderSearchConditionDto">
         SELECT COUNT(DISTINCT o.id)
           FROM orders o
-          JOIN product_order po ON o.id = po.order_id
-          JOIN product p ON po.product_id = p.id
+          JOIN franchise f ON o.franchise_id = f.id
+          JOIN hq_user_detail h ON f.department_id = h.department_id
         <where>
-            <!-- 권한 필터링 -->
-            <if test="departmentFranchiseIds != null and departmentFranchiseIds.size() > 0">
-                <choose>
-                    <when test="franchiseId != null">
-                        o.franchise_id = #{franchiseId}
-                        AND #{franchiseId} IN
-                        <foreach item="id" collection="departmentFranchiseIds" open="(" separator="," close=")">
-                            #{id}
-                        </foreach>
-                    </when>
-                    <otherwise>
-                        o.franchise_id IN
-                        <foreach item="id" collection="departmentFranchiseIds" open="(" separator="," close=")">
-                            #{id}
-                        </foreach>
-                    </otherwise>
-                </choose>
+            <!-- 접수 대기 상태는 볼 수 없음 -->
+            o.status != 'WAITING_FOR_RECEIPT'
+
+            <!-- 추가 상태 필터 있을 경우-->
+            <if test="status != null and status.trim() != '' and status != 'WAITING_FOR_RECEIPT'">
+                AND o.status = #{status}
+            </if>
+
+            <if test="userId != null">
+                AND h.user_id = #{userId}
+            </if>
+
+            <if test="franchiseId != null">
+                AND o.franchise_id = #{franchiseId}
             </if>
 
             <if test="code != null and code != ''">
@@ -105,11 +103,12 @@
             </if>
 
             <if test="product != null and product != ''">
+                AND EXISTS (
+                SELECT 1 FROM product_order po
+                JOIN product p ON po.product_id = p.id
+                WHERE po.order_id = o.id
                 AND p.name LIKE CONCAT('%', #{product}, '%')
-            </if>
-
-            <if test="status != null and status != ''">
-                AND o.status LIKE CONCAT('%', #{status}, '%')
+                )
             </if>
 
             <if test="startDate != null and endDate != null">
@@ -121,7 +120,7 @@
     <!-- 주문 기본 정보 + 가맹점 + 배송 + 출고 + 결재 -->
     <select id="findOrderDetailById" resultType="com.x1.frans.order.query.dto.OrderDetailDto">
         SELECT
-            -- 가맹점 정보
+        -- 가맹점 정보
                f.name            AS franchiseName
              , f.code            AS franchiseCode
              , f.business_number AS businessNumber
@@ -131,12 +130,12 @@
              , f.zipcode         AS zipCode
              , f.phone           AS franchisePhone
 
-            -- 주문 정보
+        -- 주문 정보
              , o.code
              , DATE (o.created_at) AS orderDate
              , o.status, o.total_amount
              , CASE WHEN o.status = 'REJECTED' THEN o.rejected_reason ELSE NULL
-           END AS rejectedReason
+               END AS rejectedReason
 
         -- 배송 정보
              , d.delivery_company AS deliveryCompany
@@ -181,24 +180,25 @@
 
     <!-- 자재 리스트 -->
     <select id="findProductsByOrderId" resultType="com.x1.frans.product.query.dto.ProductDetailDTO">
-        SELECT p.id,
-               p.code,
-               p.name,
-               p.spec,
-               p.purchase_unit        AS purchaseUnit,
-               p.unit,
-               p.product_group_id     AS productGroupId,
-               p.product_type_id      AS productTypeId,
-               p.product_attribute_id AS productAttributeId,
-               p.purchase_price       AS purchasePrice,
-               p.sale_price           AS salePrice,
-               s.name                 AS supplierName,
-               po.quantity            AS quantity
+        SELECT
+               p.id
+             , p.code
+             , p.name
+             , p.spec
+             , p.purchase_unit        AS purchaseUnit
+             , p.unit
+             , p.product_group_id     AS productGroupId
+             , p.product_type_id      AS productTypeId
+             , p.product_attribute_id AS productAttributeId
+             , p.purchase_price       AS purchasePrice
+             , p.sale_price           AS salePrice
+             , s.name                 AS supplierName
+             , po.quantity            AS quantity
 
-        FROM product_order po
-                 JOIN product p ON p.id = po.product_id
-                 JOIN supplier s ON s.id = p.supplier_id
-                 JOIN orders o ON o.id = po.order_id
+          FROM product_order po
+          JOIN product p ON p.id = po.product_id
+          JOIN supplier s ON s.id = p.supplier_id
+          JOIN orders o ON o.id = po.order_id
 
         WHERE o.id = #{orderId}
     </select>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #125 
- close #138

## ✅ 작업 사항

### 주문 취소 수정
- 그 날의 주문 마감 시간이 지났을 때, 가맹점주가 주문을 등록하면 주문 취소가 가능해야하는데 주문 마감 시간이 지났다는 예외 발생으로 취소가 되지 않던 것을 수정.

### 주문 목록 조회 조건 수정
- 본사용 주문 목록 조회 시, 접수 대기 상태는 보이지 않아야 하므로 제외함.

## 📸 스크린샷 (선택)
<br>

## 👩‍💻 공유 포인트 및 논의 사항
