### PR TITLE
✨ feat: 결재문서 회수시 임시저장상태로 변경

### DIFF
--- a/src/main/java/com/x1/frans/approval/command/application/controller/ApprovalCommandController.java
+++ b/src/main/java/com/x1/frans/approval/command/application/controller/ApprovalCommandController.java
@@ -127,4 +127,38 @@ public class ApprovalCommandController {
                 .body(CommonResponse.success(responseDTO, "결재선 템플릿이 삭제되었습니다."));
 
     }
+    @Operation(summary = "결재 수정(재기안 포함)", description = "결재를 수정합니다.")
+    @PutMapping("/{approvalId}")
+    public ResponseEntity<CommonResponse<ApprovalResponseDTO>> modifyApproval(@RequestBody ApprovalCreateRequestDTO request,
+                                                                              @AuthenticationPrincipal CustomUserDetails user,
+                                                                              @PathVariable long approvalId) {
+        long userId = user.getUserId();
+
+        ApprovalResponseDTO responseDTO = approvalCommandService.modifyApproval(request,userId, approvalId);
+
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(CommonResponse.success(responseDTO, "결재 수정이 완료되었습니다."));
+
+    }
+
+    @Operation(summary = " 결재진행 중이던 문서를 임시저장 상태로 변경", description = "결재 중이던 문서를 임시저장상태로 변경합니다.")
+    @PatchMapping("/{approvalId}/draft")
+    public ResponseEntity<CommonResponse<ApprovalResponseDTO>> updateRequestedStatus(@RequestBody ApprovalStatusUpdateDTO request,
+                                                                              @AuthenticationPrincipal CustomUserDetails user,
+                                                                              @PathVariable long approvalId) {
+        long userId = user.getUserId();
+
+        ApprovalResponseDTO responseDTO = approvalCommandService.updateRequestState(request,userId, approvalId);
+
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(CommonResponse.success(responseDTO, "임시저장 상태로 변경되었습니다."));
+
+    }
+
+
+
 }

--- a/src/main/java/com/x1/frans/approval/command/application/controller/ApprovalCommandController.java
+++ b/src/main/java/com/x1/frans/approval/command/application/controller/ApprovalCommandController.java
@@ -41,6 +41,7 @@ public class ApprovalCommandController {
 
     }
 
+
     @Operation(summary = "결재자/협조자 승인", description = "결재자/협조자가 결재를 승인합니다.")
     @PostMapping("/{approvalId}/approve")
     public ResponseEntity<CommonResponse<ApprovalResponseDTO>> approverApprove(@RequestBody ApprovalApproveRequestDTO request,
@@ -156,6 +157,21 @@ public class ApprovalCommandController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(CommonResponse.success(responseDTO, "임시저장 상태로 변경되었습니다."));
+
+    }
+
+    @Operation(summary = "임시저장된 문서를 결재등록 요청", description = "임시저장된 문서를 결재등록이 된 상태로 변경합니다.")
+    @PatchMapping("/{approvalId}/request")
+    public ResponseEntity<CommonResponse<ApprovalResponseDTO>> requestApproval(@AuthenticationPrincipal CustomUserDetails user,
+                                                                                     @PathVariable long approvalId) {
+        long userId = user.getUserId();
+
+        ApprovalResponseDTO responseDTO = approvalCommandService.requestApproval(userId, approvalId);
+
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(CommonResponse.success(responseDTO, "결재가 등록되었습니다."));
 
     }
 

--- a/src/main/java/com/x1/frans/approval/command/application/dto/ApprovalStatusUpdateDTO.java
+++ b/src/main/java/com/x1/frans/approval/command/application/dto/ApprovalStatusUpdateDTO.java
@@ -1,0 +1,10 @@
+package com.x1.frans.approval.command.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ApprovalStatusUpdateDTO {
+    private Boolean isRequested;
+}

--- a/src/main/java/com/x1/frans/approval/command/application/service/ApprovalCommandService.java
+++ b/src/main/java/com/x1/frans/approval/command/application/service/ApprovalCommandService.java
@@ -21,5 +21,5 @@ public interface ApprovalCommandService {
 
     ApprovalResponseDTO updateRequestState(ApprovalStatusUpdateDTO request, long userId, long approvalId);
 
-
+    ApprovalResponseDTO requestApproval(long userId, long approvalId);
 }

--- a/src/main/java/com/x1/frans/approval/command/application/service/ApprovalCommandService.java
+++ b/src/main/java/com/x1/frans/approval/command/application/service/ApprovalCommandService.java
@@ -16,4 +16,8 @@ public interface ApprovalCommandService {
     Optional<ApprovalResponseDTO> approvalLineTemplatesModify(ApprovalLineTemplateCreateRequestDTO request, long userId, Long templateId);
 
     Optional<ApprovalResponseDTO> deleteApprovalLineTemplates(long userId, Long templateId);
+
+    ApprovalResponseDTO modifyApproval(ApprovalCreateRequestDTO request, long userId, long approvalId);
+
+    ApprovalResponseDTO updateRequestState(ApprovalStatusUpdateDTO request, long userId, long approvalId);
 }

--- a/src/main/java/com/x1/frans/approval/command/application/service/ApprovalCommandServiceImpl.java
+++ b/src/main/java/com/x1/frans/approval/command/application/service/ApprovalCommandServiceImpl.java
@@ -381,4 +381,186 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
 
         return Optional.of(new ApprovalResponseDTO(template.getId(), template.getName()));
     }
+
+    @Transactional
+    @Override
+    public ApprovalResponseDTO modifyApproval(ApprovalCreateRequestDTO request, long userId, long approvalId) {
+
+        // 결재 문서 조회
+        ApprovalEntity approval = approvalCommandRepository.findById(approvalId)
+                .orElseThrow(() -> new ApprovalNotFoundException("결재 문서를 찾을 수 없습니다."));
+
+        // 기안자 조회
+        if (!approval.getUser().getId().equals(userId)) {
+            throw new UnauthorizedAccessException("결재 문서를 수정할 권한이 없습니다.");
+        }
+
+
+
+        if (request.getTitle() == null || request.getTitle().isBlank()) {
+            throw new IllegalArgumentException("제목은 필수 입력값입니다.");
+        }
+        if (request.getApprovalLines().isEmpty()) {
+            throw new IllegalArgumentException("결재선은 최소 1명 이상이어야 합니다.");
+        }
+        if (approval.getDegree() == null) {
+            throw new IllegalStateException("approval degree 값이 누락되었습니다.");
+        }
+        if (request.getApprovalDocuments() == null || request.getApprovalDocuments().getDocumentIds().isEmpty()) {
+            throw new IllegalArgumentException("문서 정보가 비어 있습니다.");
+        }
+
+
+        approvalFileCommandRepository.deleteByApprovalId(approvalId);
+        approvalLineCommandRepository.deleteByApprovalId(approvalId);
+        returnApprovalCommandRepository.deleteByApprovalId(approvalId);
+
+
+        approval.setTitle(request.getTitle());
+        approval.setRemarks(request.getRemarks());
+
+        if (request.getIsRequest()) {
+            approval.setIsRequested(true); // 결재 진행중
+            approval.setStatus(ApprovalStatus.IN_PROGRESS);
+
+            // degree 증가 처리
+            if (approval.getDegree() == null) {
+                approval.setDegree(1); // 최초 등록
+            } else {
+                approval.setDegree(approval.getDegree() + 1); // 재기안
+            }
+
+        } else {
+            approval.setIsRequested(false); // 임시저장
+            approval.setStatus(ApprovalStatus.DRAFT);
+
+            // 임시저장일 경우 degree를 0으로 설정 -기안 전 상태
+            if (approval.getDegree() == null) {
+                approval.setDegree(0);
+            }
+        }
+        orderApprovalCommandRepository.deleteByApprovalId(approvalId);
+        purchaseOrderApprovalCommandRepository.deleteByApprovalId(approvalId);
+
+
+
+
+        // 결재 문서
+        ApprovalDocumentDTO doc = request.getApprovalDocuments();
+
+        switch (doc.getCategoryType()) {
+            case ORDER -> {
+                List<OrderApprovalEntity> orderDocs = doc.getDocumentIds().stream()
+                        .map(docId -> new OrderApprovalEntity(approval, docId))
+                        .toList();
+                orderApprovalCommandRepository.saveAll(orderDocs);
+            }
+
+            case RETURN -> {
+                List<ReturnApprovalEntity> returnDocs = doc.getDocumentIds().stream()
+                        .map(docId -> new ReturnApprovalEntity(approval, docId))
+                        .toList();
+                returnApprovalCommandRepository.saveAll(returnDocs);
+            }
+
+            case PURCHASE_ORDER -> {
+                List<PurchaseOrderApprovalEntity> purchaseOrderDocs = doc.getDocumentIds().stream()
+                        .map(docId -> new PurchaseOrderApprovalEntity(approval, docId))
+                        .toList();
+                purchaseOrderApprovalCommandRepository.saveAll(purchaseOrderDocs);
+            }
+
+            default -> throw new IllegalArgumentException("알 수 없는 문서 유형입니다.");
+        }
+
+        // 결재선 처리
+        List<ApprovalLineEntity> approvalLines = request.getApprovalLines().stream()
+                .map(line -> {
+                    UserEntity approver = userCommandRepository.findById(line.getUserId())
+                            .orElseThrow(() -> new UserNotFoundException("결재자 정보를 찾을 수 없습니다."));
+
+                    ApprovalLineEntity approvalLine = new ApprovalLineEntity();
+                    approvalLine.setApproval(approval);
+                    approvalLine.setUser(approver);
+                    approvalLine.setSeq(line.getSeq());
+                    approvalLine.setApprovalType(ApprovalLineType.valueOf(line.getType()));
+                    if (approval.getDegree() != null) {
+                        approvalLine.setApprovalDegree(approval.getDegree().longValue());
+                    }
+                    return approvalLine;
+                }).toList();
+
+
+        // 순서가 필요한 라인만 필터링 (결재자, 협조자)
+        List<ApprovalLineEntity> orderedLines = approvalLines.stream()
+                .filter(line -> line.getApprovalType().isOrdered())
+                .sorted(Comparator.comparingInt(ApprovalLineEntity::getSeq))
+                .collect(toList());
+
+        // 순서 필요 없는 나머지 (참조자, 수신자)
+        List<ApprovalLineEntity> referenceLines = approvalLines.stream()
+                .filter(line -> !line.getApprovalType().isOrdered())
+                .collect(toList());
+
+        // 상태 설정 enum 메서드에 위임
+        for (int i = 0; i < orderedLines.size(); i++) {
+            ApprovalLineEntity line = orderedLines.get(i);
+            line.setStatus(line.getApprovalType().getInitialStatus(i));
+        }
+
+
+        // 결재선 저장
+        List<ApprovalLineEntity> allLines = new ArrayList<>();
+        allLines.addAll(orderedLines);
+        allLines.addAll(referenceLines);
+
+        // 참조자/수신자는 상태 없이 저장
+        referenceLines.forEach(line -> line.setStatus(null));
+
+        approvalLineCommandRepository.saveAll(allLines);
+
+
+        // 첨부파일
+        List<ApprovalFileEntity> fileEntities = request.getFiles()== null ? List.of() :
+                request.getFiles().stream()
+                        .map(file -> {
+                            ApprovalFileEntity approvalFile = new ApprovalFileEntity();
+                            approvalFile.setApproval(approval);
+                            approvalFile.setName(file.getName());
+                            approvalFile.setUrl(file.getUrl());
+                            return approvalFile;
+                        }).toList();
+
+        approvalFileCommandRepository.saveAll(fileEntities);
+
+
+        return new ApprovalResponseDTO(approval.getId(), approval.getTitle());
+
+    }
+
+    @Transactional
+    @Override
+    public ApprovalResponseDTO updateRequestState(ApprovalStatusUpdateDTO request, long userId, long approvalId) {
+
+        ApprovalEntity approval = approvalCommandRepository.findById(approvalId)
+                .orElseThrow(() -> new ApprovalNotFoundException("결재문서가 존재하지 않습니다."));
+
+
+        if (!approval.getUser().getId().equals(userId)) {
+            throw new UnauthorizedAccessException("결재 수정 권한 없습니다.");
+        }
+
+        approval.setIsRequested(request.getIsRequested());
+
+        // 요청이 해제 (isRequested == false) → 상태를 DRAFT로 변경
+        if (Boolean.FALSE.equals(request.getIsRequested())) {
+            approval.setStatus(ApprovalStatus.DRAFT);
+        }
+
+        approvalCommandRepository.save(approval);
+
+
+        return new ApprovalResponseDTO(approval.getId(), approval.getTitle());
+
+    }
 }

--- a/src/main/java/com/x1/frans/approval/command/application/service/ApprovalCommandServiceImpl.java
+++ b/src/main/java/com/x1/frans/approval/command/application/service/ApprovalCommandServiceImpl.java
@@ -55,6 +55,10 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
         // 결재 코드 생성
         String newCode = generateApprovalCode();
 
+        int degree = 1;
+         degree = approvalCommandRepository.findMaxDegreeByCode(newCode) + 1;
+
+
         // 결재 엔티티 생성
         ApprovalEntity approval = new ApprovalEntity();
         approval.setTitle(request.getTitle());
@@ -63,6 +67,7 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
         approval.setIsRequested(request.getIsRequest());
         approval.setUser(user); // 연관관계 설정
         approval.setCode(newCode);
+        approval.setDegree(degree);
 
         // 저장
         approvalCommandRepository.save(approval);
@@ -166,6 +171,7 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
 
         return generateSequentialCode(codePrefix, latestCode);
     }
+
 
     private String generateSequentialCode(String codePrefix, String latestCode) {
         int nextSeq = 1;
@@ -414,6 +420,7 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
         approvalFileCommandRepository.deleteByApprovalId(approvalId);
         approvalLineCommandRepository.deleteByApprovalId(approvalId);
         returnApprovalCommandRepository.deleteByApprovalId(approvalId);
+        orderApprovalCommandRepository.deleteByApprovalId(approvalId);
 
 
         approval.setTitle(request.getTitle());
@@ -439,7 +446,6 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
                 approval.setDegree(0);
             }
         }
-        orderApprovalCommandRepository.deleteByApprovalId(approvalId);
         purchaseOrderApprovalCommandRepository.deleteByApprovalId(approvalId);
 
 
@@ -564,4 +570,26 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
 
     }
 
+    @Transactional
+    @Override
+    public ApprovalResponseDTO requestApproval(long userId, long approvalId) {
+
+        ApprovalEntity approval = approvalCommandRepository.findById(approvalId)
+                .orElseThrow(() -> new ApprovalNotFoundException("결재문서가 존재하지 않습니다."));
+
+        if (!approval.getUser().getId().equals(userId)) {
+            throw new UnauthorizedAccessException("결재 수정 권한이 없습니다.");
+        }
+
+        if (approval.getIsRequested()) {
+            throw new IllegalStateException("이미 결재 요청된 문서입니다.");
+        }
+
+        approval.setIsRequested(true);
+        approval.setStatus(ApprovalStatus.IN_PROGRESS);
+
+        approvalCommandRepository.save(approval);
+
+        return new ApprovalResponseDTO(approval.getId(), approval.getCode(), approval.getCreatedAt());
+    }
 }

--- a/src/main/java/com/x1/frans/approval/command/domain/aggregate/ApprovalEntity.java
+++ b/src/main/java/com/x1/frans/approval/command/domain/aggregate/ApprovalEntity.java
@@ -55,7 +55,6 @@ public class ApprovalEntity {
 
     @PrePersist
     protected void onCreate() {
-        this.degree = 1;
         this.createdAt = LocalDateTime.now();
         this.isDeleted = false;
     }

--- a/src/main/java/com/x1/frans/approval/command/domain/repository/ApprovalCommandRepository.java
+++ b/src/main/java/com/x1/frans/approval/command/domain/repository/ApprovalCommandRepository.java
@@ -2,6 +2,10 @@ package com.x1.frans.approval.command.domain.repository;
 
 import com.x1.frans.approval.command.domain.aggregate.ApprovalEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ApprovalCommandRepository extends JpaRepository<ApprovalEntity,Long> {
+    @Query("SELECT COALESCE(MAX(a.degree), 0) FROM ApprovalEntity a WHERE a.code = :code")
+    int findMaxDegreeByCode(@Param("code") String code);
 }

--- a/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/x1/frans/approval/query/service/ApprovalQueryService.java
@@ -60,4 +60,5 @@ public interface ApprovalQueryService {
     List<ApprovalLinesDTO> getApprovalLineTemplates(long userId);
 
     List<ApprovalLinesDTO> getApprovalLineDetailTemplates(long userId, long templateId);
+
 }

--- a/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/approval/query/repository/ApprovalQueryMapper.xml
@@ -17,10 +17,6 @@
 
     </resultMap>
 
-    <!-- 결재 수신 관련 목록 조회 -->
-    <select id="getApprovalListReceivedAll" resultMap="getApprovalListMap">
-
-    </select>
     <!-- 결재 상신 관련 -->
     <select id="getApprovalListSubmittedAll" resultMap="getApprovalListMap">
         SELECT


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #140 

## ✅ 작업 사항
- 결재문서 회수시 임시저장 상태로 변경
- 임시저장된 문서 결재 등록
<br>

## 📸 스크린샷 
<br>

## 결재문서 회수시 임시저장 상태로 변경
- 결재등록된 상태
<img width="1274" alt="재기안전" src="https://github.com/user-attachments/assets/8e3cad16-f11d-416f-99de-20ea356e320c" />
- 문서회수된 상태(임시저장)
<img width="1262" alt="id 37번 문서회수" src="https://github.com/user-attachments/assets/1db0f115-3287-494d-8a48-91c774967ca4" />




## 임시저장된 문서 결재 등록
- 임시저장되어있는 문서번호 38번
<img width="1291" alt="임시저장된 38번" src="https://github.com/user-attachments/assets/80d43dac-72c9-4066-a923-9e1632ffaf80" />
- 문서번호 38번 요청처리됨을 알 수있음
<img width="1272" alt="요청처리됨을 알 수있음" src="https://github.com/user-attachments/assets/0359d938-e913-482a-882e-724a408fa16f" />

## 👩‍💻 공유 포인트 및 논의 사항
