### PR TITLE
🚑 fix: 배송 정보에 배송 완료일 추가

### DIFF
--- a/src/main/java/com/x1/frans/order/command/application/controller/HqOrderCommandController.java
+++ b/src/main/java/com/x1/frans/order/command/application/controller/HqOrderCommandController.java
@@ -96,7 +96,7 @@ public class HqOrderCommandController {
     )
     public ResponseEntity<Void> updateOrderStatusAndDelivery(
             @PathVariable Long orderId,
-            @RequestBody OrderStatusUpdateRequestDto dto,
+            @RequestBody @Valid OrderStatusUpdateRequestDto dto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         hqOrderCommandService.updateOrderStatusAndDelivery(orderId, dto, userDetails.getUserId());
@@ -107,7 +107,7 @@ public class HqOrderCommandController {
     @PatchMapping("/{orderId}/delivery")
     @Operation(
             summary = "배송 정보 등록 또는 수정",
-            description = "결재 완료 상태의 주문에 배송 정보를 입력하고 상태를 배송 중으로 변경합니다. (주문 상태도 같이 변경)"
+            description = "결재 완료 또는 배송 중 상태의 주문에 배송 정보를 입력합니다. 최초 등록 시 주문 상태가 배송 중으로 변경됩니다."
     )
     public ResponseEntity<Void> registerOrUpdateDelivery(
             @PathVariable Long orderId,

--- a/src/main/java/com/x1/frans/order/command/application/dto/DeliveryInfoRequestDto.java
+++ b/src/main/java/com/x1/frans/order/command/application/dto/DeliveryInfoRequestDto.java
@@ -3,6 +3,8 @@ package com.x1.frans.order.command.application.dto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 public class DeliveryInfoRequestDto {
 
@@ -17,4 +19,6 @@ public class DeliveryInfoRequestDto {
 
     @NotBlank(message = "배송 기사 연락처는 필수입니다.")
     private String phone;
+
+    private LocalDate deliveredAt;
 }

--- a/src/main/java/com/x1/frans/order/command/application/dto/OrderStatusUpdateRequestDto.java
+++ b/src/main/java/com/x1/frans/order/command/application/dto/OrderStatusUpdateRequestDto.java
@@ -4,9 +4,13 @@ import com.x1.frans.order.command.domain.vo.OrderStatus;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 public class OrderStatusUpdateRequestDto {
 
     @NotBlank(message = "주문 상태는 필수입니다.")
     private OrderStatus status;
+
+    private LocalDate deliveredAt;
 }

--- a/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/command/application/service/HqOrderCommandServiceImpl.java
@@ -80,7 +80,8 @@ public class HqOrderCommandServiceImpl implements HqOrderCommandService {
     public void registerOrUpdateDelivery(Long orderId, Long userId, DeliveryInfoRequestDto dto) {
         Order order = orderAuthorizationService.getAuthorizedOrder(orderId, userId);
 
-        if (!(order.getStatus().equals(OrderStatus.APPROVED) || order.getStatus().equals(OrderStatus.DELIVERING))) {
+        OrderStatus currentStatus = order.getStatus();
+        if (!(currentStatus.equals(OrderStatus.APPROVED) || currentStatus.equals(OrderStatus.DELIVERING))) {
             throw new InvalidRejectConditionException("배송 정보는 '결재 완료' 또는 '배송 중' 상태에서만 등록/수정할 수 있습니다.");
         }
 
@@ -88,7 +89,11 @@ public class HqOrderCommandServiceImpl implements HqOrderCommandService {
         boolean isNew = false;
 
         if (delivery == null) {
-            // 최초 등록 (배송 상태 - '배송 중')
+            // 최초 등록
+            if (dto.getDeliveredAt() != null) {
+                throw new InvalidRejectConditionException("배송 정보 등록 시점에는 배송 완료일을 입력할 수 없습니다.");
+            }
+
             delivery = Delivery.builder()
                     .code("DLV-" + System.currentTimeMillis())
                     .status(DeliveryStatus.DELIVERING)
@@ -99,25 +104,27 @@ public class HqOrderCommandServiceImpl implements HqOrderCommandService {
                     .build();
             isNew = true;
         } else {
-            // 수정 (배송 상태 - 유지)
+            // 기존 배송 정보 수정
             delivery.updateDeliveryInfo(dto.getDeliveryCompany(), dto.getTrackingNumber(), dto.getName(), dto.getPhone());
+
+            // 배송 완료일이 포함된 경우 → 완료 처리
+            if (dto.getDeliveredAt() != null) {
+                delivery.completeDelivery(dto.getDeliveredAt());
+                order.updateStatus(OrderStatus.DELIVERED);
+            }
         }
 
         deliveryRepository.save(delivery);
-        order.assignDelivery(delivery);
 
         if (isNew) {
-            // 최초 등록 시에만 주문 상태도 배송 중으로 변경
-            order.updateStatus(OrderStatus.DELIVERING);
+            order.assignDelivery(delivery);
+            order.updateStatus(OrderStatus.DELIVERING); // 최초 등록 시에만 배송 중으로 전환
         }
     }
 
 
     @Override
     public void setOrderStatusToDelivering(List<Long> orderIds) {
-
         orderCommandRepository.updateOrderStatusToDelivering(orderIds);
     }
-
-
 }

--- a/src/main/java/com/x1/frans/order/command/domain/aggregate/Delivery.java
+++ b/src/main/java/com/x1/frans/order/command/domain/aggregate/Delivery.java
@@ -4,7 +4,7 @@ import com.x1.frans.user.enums.DeliveryStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "delivery")
@@ -31,14 +31,8 @@ public class Delivery {
     @Column(name = "tracking_number")
     private String trackingNumber;
 
-    @Column(name = "shipped_at")
-    private LocalDateTime shippedAt;
-
     @Column(name = "delivered_at")
-    private LocalDateTime deliveredAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
+    private LocalDate deliveredAt;
 
     @Column(name = "name")
     private String name;
@@ -46,21 +40,16 @@ public class Delivery {
     @Column(name = "phone")
     private String phone;
 
-    @PrePersist
-    public void prePersist() {
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    @PreUpdate
-    public void preUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
-
     public void updateDeliveryInfo(String deliveryCompany, String trackingNumber, String name, String phone) {
         this.deliveryCompany = deliveryCompany;
         this.trackingNumber = trackingNumber;
         this.name = name;
         this.phone = phone;
+    }
+
+    public void completeDelivery(LocalDate deliveredAt) {
+        this.deliveredAt = deliveredAt;
+        this.status = DeliveryStatus.DELIVERED; // 배송 완료 상태로 변경
     }
 
 }


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #153 

## ✅ 작업 사항

### 배송 정보 최초 입력 시
- 결재 완료 상태에서 배송 정보를 최초 입력할 수 있다. 
- 배송 중으로 상태가 변경된다.

### 배송 완료 일 입력 시
- 배송 중 상태에서 배송 완료 일을 입력(배송 정보 수정)할 수 있다.
- 배송 완료로 상태가 변경된다. 

### 배송 중 상태일 때
<img width="1057" alt="Image" src="https://github.com/user-attachments/assets/9849b0d3-9b0c-4981-817d-81bb885f5e70" />

### 배송 완료 일을 입력했을 때
<img width="905" alt="Image" src="https://github.com/user-attachments/assets/5036ecdc-d8ad-4a09-a70a-3f8639b92ec6" />

### 배송 완료일 입력 후 
<img width="1082" alt="Image" src="https://github.com/user-attachments/assets/13fb7db5-7316-48d7-8be3-426c241c0fec" />

<br>
###예외

### 결재 완료 상태에서 배송 정보를 최초 입력할 때 -> 배송 완료 일을 입력하면 예외 발생
<img width="892" alt="Image" src="https://github.com/user-attachments/assets/f2390fbe-f183-4eef-9b78-e09e8f37d31a" />

## 📸 스크린샷 (선택)
<br>

## 👩‍💻 공유 포인트 및 논의 사항
