### PR TITLE
✨ feat: 가맹점용 주문 상세 조회 구현

### DIFF
--- a/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
+++ b/src/main/java/com/x1/frans/order/query/controller/FranchiseOrderQueryController.java
@@ -1,5 +1,6 @@
 package com.x1.frans.order.query.controller;
 
+import com.x1.frans.order.query.dto.FranchiseOrderDetailDto;
 import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 import com.x1.frans.order.query.service.FranchiseOrderQueryService;
@@ -7,11 +8,9 @@ import com.x1.frans.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/franchise/orders")
@@ -22,12 +21,31 @@ public class FranchiseOrderQueryController {
     private final FranchiseOrderQueryService franchiseOrderQueryService;
 
     @GetMapping
-    @Operation(summary = "주문 목록 조회", description = "가맹점 유저가 자신의 주문 목록을 조회합니다.")
+    @Operation(
+            summary = "주문 목록 조회",
+            description = "가맹점 유저가 자신의 주문 목록을 조회합니다."
+    )
     public OrderSearchPageResponseDto searchOrders(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @ModelAttribute OrderSearchConditionDto condition) {
 
         Long userId = userDetails.getUserId();
         return franchiseOrderQueryService.searchOrders(condition, userId);
+    }
+
+    @GetMapping("/{orderId}")
+    @Operation(
+            summary = "주문 상세 조회",
+            description = "가맹점 유저가 자신의 주문 상세 정보를 조회합니다."
+    )
+    public ResponseEntity<FranchiseOrderDetailDto> getOrderDetail(
+            @PathVariable Long orderId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long userId = userDetails.getUserId();
+
+        FranchiseOrderDetailDto dto = franchiseOrderQueryService.getFranchiseOrderDetail(orderId, userId);
+
+        return ResponseEntity.ok(dto);
     }
 }

--- a/src/main/java/com/x1/frans/order/query/controller/HqOrderQueryController.java
+++ b/src/main/java/com/x1/frans/order/query/controller/HqOrderQueryController.java
@@ -1,6 +1,6 @@
 package com.x1.frans.order.query.controller;
 
-import com.x1.frans.order.query.dto.OrderDetailDto;
+import com.x1.frans.order.query.dto.HqOrderDetailDto;
 import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 import com.x1.frans.order.query.service.HqOrderQueryService;
@@ -38,13 +38,13 @@ public class HqOrderQueryController {
             summary = "주문 상세 조회",
             description = "주문 ID로 주문 상세 정보를 조회합니다."
     )
-    public ResponseEntity<OrderDetailDto> getOrderDetail(
+    public ResponseEntity<HqOrderDetailDto> getOrderDetail(
             @PathVariable Long orderId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         Long userId = userDetails.getUserId();
 
-        OrderDetailDto dto = orderQueryService.getOrderDetail(orderId, userId);
+        HqOrderDetailDto dto = orderQueryService.getOrderDetail(orderId, userId);
 
         return ResponseEntity.ok(dto);
     }

--- a/src/main/java/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.java
+++ b/src/main/java/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.java
@@ -1,8 +1,11 @@
 package com.x1.frans.order.query.dao;
 
+import com.x1.frans.order.query.dto.FranchiseOrderDetailDto;
 import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
+import com.x1.frans.product.query.dto.ProductDetailDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -13,4 +16,10 @@ public interface FranchiseOrderQueryMapper {
 
     // 전체 개수 조회 (페이징 계산용)
     int countOrders(OrderSearchConditionDto condition);
+
+    FranchiseOrderDetailDto findFranchiseOrderDetailById(@Param("orderId") Long orderId, @Param("userId") Long userId);
+
+    List<ProductDetailDTO> findProductsByOrderId(@Param("orderId") Long orderId);
+
+
 }

--- a/src/main/java/com/x1/frans/order/query/dao/HqOrderQueryMapper.java
+++ b/src/main/java/com/x1/frans/order/query/dao/HqOrderQueryMapper.java
@@ -1,6 +1,6 @@
 package com.x1.frans.order.query.dao;
 
-import com.x1.frans.order.query.dto.OrderDetailDto;
+import com.x1.frans.order.query.dto.HqOrderDetailDto;
 import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
 import com.x1.frans.product.query.dto.ProductDetailDTO;
@@ -17,7 +17,7 @@ public interface HqOrderQueryMapper {
     // 전체 개수 조회 (페이징 계산용)
     int countOrders(OrderSearchConditionDto condition);
 
-    OrderDetailDto findOrderDetailById(@Param("orderId") Long orderId);
+    HqOrderDetailDto findOrderDetailById(@Param("orderId") Long orderId);
 
     List<ProductDetailDTO> findProductsByOrderId(@Param("orderId") Long orderId);
 

--- a/src/main/java/com/x1/frans/order/query/dto/FranchiseOrderDetailDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/FranchiseOrderDetailDto.java
@@ -10,8 +10,7 @@ import java.util.List;
 
 @Getter
 @Setter
-public class OrderDetailDto {
-
+public class FranchiseOrderDetailDto {
     // 가맹점 정보
     private String franchiseName;
     private String franchiseCode;
@@ -40,16 +39,4 @@ public class OrderDetailDto {
     private String driverPhone;
     private String trackingNumber;
     private LocalDate deliveredAt;
-
-    // 출고 정보
-    private String outboundCode;
-    private LocalDate outboundDate;
-    private String outboundManager;
-
-    // 결재 정보
-    private String approvalCode;
-    private String approvalRequester;
-    private LocalDate approvalRequestedAt;
-    private String approvalStatus;
-    private LocalDate approvalCompletedAt;
 }

--- a/src/main/java/com/x1/frans/order/query/dto/HqOrderDetailDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/HqOrderDetailDto.java
@@ -1,0 +1,55 @@
+package com.x1.frans.order.query.dto;
+
+import com.x1.frans.product.query.dto.ProductDetailDTO;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+public class HqOrderDetailDto {
+
+    // 가맹점 정보
+    private String franchiseName;
+    private String franchiseCode;
+    private String businessNumber;
+    private String ceoName;
+    private LocalDate franchiseSignedAt;
+
+    private String franchiseAddress;
+    private String zipCode;
+    private String franchisePhone;
+
+    // 주문 정보
+    private String status;
+    private String code;
+    private LocalDate orderDate;
+    private BigDecimal totalAmount;
+    private int totalQuantity;
+    private String rejectedReason;
+
+    // 자재 정보
+    private List<ProductDetailDTO> products;
+
+    // 배송 정보
+    private String deliveryCompany;
+    private String driverName;
+    private String driverPhone;
+    private String trackingNumber;
+    private LocalDate deliveredAt;
+
+    // 출고 정보
+    private String outboundCode;
+    private LocalDate outboundDate;
+    private String outboundManager;
+
+    // 결재 정보
+    private String approvalCode;
+    private String approvalRequester;
+    private LocalDate approvalRequestedAt;
+    private String approvalStatus;
+    private LocalDate approvalCompletedAt;
+}

--- a/src/main/java/com/x1/frans/order/query/dto/OrderDetailDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/OrderDetailDto.java
@@ -39,6 +39,7 @@ public class OrderDetailDto {
     private String driverName;
     private String driverPhone;
     private String trackingNumber;
+    private LocalDate deliveredAt;
 
     // 출고 정보
     private String outboundCode;

--- a/src/main/java/com/x1/frans/order/query/service/FranchiseOrderQueryService.java
+++ b/src/main/java/com/x1/frans/order/query/service/FranchiseOrderQueryService.java
@@ -1,8 +1,11 @@
 package com.x1.frans.order.query.service;
 
+import com.x1.frans.order.query.dto.FranchiseOrderDetailDto;
 import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 
 public interface FranchiseOrderQueryService {
     OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition, Long userId);
+
+    FranchiseOrderDetailDto getFranchiseOrderDetail(Long orderId, Long userId);
 }

--- a/src/main/java/com/x1/frans/order/query/service/FranchiseOrderQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/query/service/FranchiseOrderQueryServiceImpl.java
@@ -1,9 +1,13 @@
 package com.x1.frans.order.query.service;
 
+import com.x1.frans.exception.OrderNotFoundException;
 import com.x1.frans.order.query.dao.FranchiseOrderQueryMapper;
+import com.x1.frans.order.query.dto.FranchiseOrderDetailDto;
 import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
+import com.x1.frans.order.query.service.support.OrderDetailCalculator;
+import com.x1.frans.product.query.dto.ProductDetailDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +19,7 @@ import java.util.List;
 public class FranchiseOrderQueryServiceImpl implements FranchiseOrderQueryService {
 
     private final FranchiseOrderQueryMapper franchiseOrderQueryMapper;
+    private final OrderDetailCalculator orderDetailCalculator;
 
     @Override
     @Transactional
@@ -37,6 +42,19 @@ public class FranchiseOrderQueryServiceImpl implements FranchiseOrderQueryServic
                 .hasNext(condition.getPage() < totalPages)
                 .hasPrevious(condition.getPage() > 1)
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public FranchiseOrderDetailDto getFranchiseOrderDetail(Long orderId, Long userId) {
+        FranchiseOrderDetailDto detail = franchiseOrderQueryMapper.findFranchiseOrderDetailById(orderId, userId);
+        if (detail == null) {
+            throw new OrderNotFoundException("해당 주문을 찾을 수 없거나 접근 권한이 없습니다.");
+        }
+
+        List<ProductDetailDTO> products = franchiseOrderQueryMapper.findProductsByOrderId(orderId);
+        orderDetailCalculator.frfillDetails(detail, products);
+        return detail;
     }
 
 }

--- a/src/main/java/com/x1/frans/order/query/service/HqOrderQueryService.java
+++ b/src/main/java/com/x1/frans/order/query/service/HqOrderQueryService.java
@@ -1,11 +1,11 @@
 package com.x1.frans.order.query.service;
 
-import com.x1.frans.order.query.dto.OrderDetailDto;
+import com.x1.frans.order.query.dto.HqOrderDetailDto;
 import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 
 public interface HqOrderQueryService {
     OrderSearchPageResponseDto searchOrders(OrderSearchConditionDto condition, Long userId);
 
-    OrderDetailDto getOrderDetail(Long orderId, Long userId);
+    HqOrderDetailDto getOrderDetail(Long orderId, Long userId);
 }

--- a/src/main/java/com/x1/frans/order/query/service/HqOrderQueryServiceImpl.java
+++ b/src/main/java/com/x1/frans/order/query/service/HqOrderQueryServiceImpl.java
@@ -3,7 +3,7 @@ package com.x1.frans.order.query.service;
 import com.x1.frans.exception.OrderNotFoundException;
 import com.x1.frans.order.common.OrderAuthorizationService;
 import com.x1.frans.order.query.dao.HqOrderQueryMapper;
-import com.x1.frans.order.query.dto.OrderDetailDto;
+import com.x1.frans.order.query.dto.HqOrderDetailDto;
 import com.x1.frans.order.query.dto.OrderSearchConditionDto;
 import com.x1.frans.order.query.dto.OrderSearchPageResponseDto;
 import com.x1.frans.order.query.dto.OrderSummaryResponseDto;
@@ -39,27 +39,16 @@ public class HqOrderQueryServiceImpl implements HqOrderQueryService {
 
     @Override
     @Transactional
-    public OrderDetailDto getOrderDetail(Long orderId, Long userId) {
-        validateOrderAccess(orderId, userId);
-        OrderDetailDto detail = fetchOrderDetail(orderId);
-        List<ProductDetailDTO> products = fetchProductDetails(orderId);
-        orderDetailCalculator.fillDetails(detail, products);
-        return detail;
-    }
-
-    private void validateOrderAccess(Long orderId, Long userId) {
+    public HqOrderDetailDto getOrderDetail(Long orderId, Long userId) {
         orderAuthorizationService.getAuthorizedOrder(orderId, userId);
-    }
 
-    private OrderDetailDto fetchOrderDetail(Long orderId) {
-        OrderDetailDto detail = orderQueryMapper.findOrderDetailById(orderId);
+        HqOrderDetailDto detail = orderQueryMapper.findOrderDetailById(orderId);
         if (detail == null) {
             throw new OrderNotFoundException("주문 상세 정보를 찾을 수 없습니다.");
         }
-        return detail;
-    }
 
-    private List<ProductDetailDTO> fetchProductDetails(Long orderId) {
-        return orderQueryMapper.findProductsByOrderId(orderId);
+        List<ProductDetailDTO> products = orderQueryMapper.findProductsByOrderId(orderId);
+        orderDetailCalculator.fillDetails(detail, products);
+        return detail;
     }
 }

--- a/src/main/java/com/x1/frans/order/query/service/support/OrderDetailCalculator.java
+++ b/src/main/java/com/x1/frans/order/query/service/support/OrderDetailCalculator.java
@@ -1,6 +1,7 @@
 package com.x1.frans.order.query.service.support;
 
-import com.x1.frans.order.query.dto.OrderDetailDto;
+import com.x1.frans.order.query.dto.FranchiseOrderDetailDto;
+import com.x1.frans.order.query.dto.HqOrderDetailDto;
 import com.x1.frans.product.query.dto.ProductDetailDTO;
 import org.springframework.stereotype.Component;
 
@@ -10,7 +11,13 @@ import java.util.List;
 @Component
 public class OrderDetailCalculator {
 
-    public void fillDetails(OrderDetailDto detail, List<ProductDetailDTO> products) {
+    public void fillDetails(HqOrderDetailDto detail, List<ProductDetailDTO> products) {
+        detail.setProducts(products);
+        detail.setTotalQuantity(calculateTotalQuantity(products));
+        detail.setTotalAmount(calculateTotalAmount(products));
+    }
+
+    public void frfillDetails(FranchiseOrderDetailDto detail, List<ProductDetailDTO> products) {
         detail.setProducts(products);
         detail.setTotalQuantity(calculateTotalQuantity(products));
         detail.setTotalAmount(calculateTotalAmount(products));

--- a/src/main/resources/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.xml
@@ -85,4 +85,65 @@
         </where>
     </select>
 
+    <!-- 가맹점 주문 상세 조회 -->
+    <select id="findFranchiseOrderDetailById" resultType="com.x1.frans.order.query.dto.FranchiseOrderDetailDto">
+        SELECT
+        -- 가맹점 정보
+            f.name            AS franchiseName
+             , f.code            AS franchiseCode
+             , f.business_number AS businessNumber
+             , u.name            AS ceoName
+             , f.signed_at       AS franchiseSignedAt
+             , f.address         AS franchiseAddress
+             , f.zipcode         AS zipCode
+             , f.phone           AS franchisePhone
+
+        -- 주문 정보
+             , o.code
+             , DATE(o.created_at) AS orderDate
+             , o.status
+             , o.total_amount
+             , CASE WHEN o.status = 'REJECTED'
+            THEN o.rejected_reason ELSE NULL
+        END AS rejectedReason
+
+        -- 배송 정보
+        , d.delivery_company   AS deliveryCompany
+        , d.name               AS driverName
+        , d.phone              AS driverPhone
+        , d.tracking_number    AS trackingNumber
+        , DATE(d.delivered_at) AS deliveredAt
+
+    FROM orders o
+    JOIN franchise f ON o.franchise_id = f.id
+    JOIN user u ON f.owner_id = u.id
+    LEFT JOIN delivery d ON o.delivery_id = d.id
+    WHERE o.id = #{orderId}
+        AND f.owner_id = #{userId}
+    </select>
+
+    <!-- 가맹점 주문 자재 리스트 -->
+    <select id="findProductsByOrderId" resultType="com.x1.frans.product.query.dto.ProductDetailDTO">
+        SELECT
+            p.id
+             , p.code
+             , p.name
+             , p.spec
+             , p.purchase_unit        AS purchaseUnit
+             , p.unit
+             , p.product_group_id     AS productGroupId
+             , p.product_type_id      AS productTypeId
+             , p.product_attribute_id AS productAttributeId
+             , p.purchase_price       AS purchasePrice
+             , p.sale_price           AS salePrice
+             , s.name                 AS supplierName
+             , po.quantity            AS quantity
+        FROM product_order po
+        JOIN product p ON po.product_id = p.id
+        JOIN supplier s ON p.supplier_id = s.id
+        JOIN orders o ON o.id = po.order_id
+        WHERE o.id = #{orderId}
+    </select>
+
+
 </mapper>

--- a/src/main/resources/com/x1/frans/order/query/dao/HqOrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/HqOrderQueryMapper.xml
@@ -117,42 +117,45 @@
         </where>
     </select>
 
-    <!-- 주문 기본 정보 + 가맹점 + 배송 + 출고 + 결재 -->
+    <!-- 본사용 주문 상세 조회 (가맹점 + 주문 + 배송 + 출고 + 결재) -->
     <select id="findOrderDetailById" resultType="com.x1.frans.order.query.dto.OrderDetailDto">
         SELECT
         -- 가맹점 정보
-               f.name            AS franchiseName
-             , f.code            AS franchiseCode
-             , f.business_number AS businessNumber
-             , u.name            AS ceoName
-             , f.signed_at       AS franchiseSignedAt
-             , f.address         AS franchiseAddress
-             , f.zipcode         AS zipCode
-             , f.phone           AS franchisePhone
+               f.name                   AS franchiseName
+             , f.code                   AS franchiseCode
+             , f.business_number        AS businessNumber
+             , u.name                   AS ceoName
+             , f.signed_at              AS franchiseSignedAt
+             , f.address                AS franchiseAddress
+             , f.zipcode                AS zipCode
+             , f.phone                  AS franchisePhone
 
         -- 주문 정보
              , o.code
              , DATE (o.created_at) AS orderDate
-             , o.status, o.total_amount
-             , CASE WHEN o.status = 'REJECTED' THEN o.rejected_reason ELSE NULL
+             , o.status
+             , o.total_amount
+             , CASE WHEN o.status = 'REJECTED'
+               THEN o.rejected_reason ELSE NULL
                END AS rejectedReason
 
         -- 배송 정보
-             , d.delivery_company AS deliveryCompany
-             , d.name AS driverName
-             , d.phone AS driverPhone
-             , d.tracking_number AS trackingNumber
+             , d.delivery_company       AS deliveryCompany
+             , d.name                   AS driverName
+             , d.phone                  AS driverPhone
+             , d.tracking_number        AS trackingNumber
+             , DATE(d.delivered_at)     AS deliveredAt
 
         -- 출고 정보
-             , ob_sub.code AS outboundCode
-             , DATE(ob_sub.shipped_at) AS outboundDate
-             , u2.name AS outboundManager
+             , ob_sub.code              AS outboundCode
+             , DATE(ob_sub.shipped_at)  AS outboundDate
+             , u2.name                  AS outboundManager
 
         -- 결재 정보
-             , a_sub.code AS approvalCode
-             , u3.name AS approvalRequester
-             , DATE(a_sub.created_at) AS approvalRequestedAt
-             , a_sub.status AS approvalStatus
+             , a_sub.code               AS approvalCode
+             , u3.name                  AS approvalRequester
+             , DATE(a_sub.created_at)   AS approvalRequestedAt
+             , a_sub.status             AS approvalStatus
              , DATE(a_sub.processed_at) AS approvalCompletedAt
 
           FROM orders o

--- a/src/main/resources/com/x1/frans/order/query/dao/HqOrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/HqOrderQueryMapper.xml
@@ -118,7 +118,7 @@
     </select>
 
     <!-- 본사용 주문 상세 조회 (가맹점 + 주문 + 배송 + 출고 + 결재) -->
-    <select id="findOrderDetailById" resultType="com.x1.frans.order.query.dto.OrderDetailDto">
+    <select id="findOrderDetailById" resultType="com.x1.frans.order.query.dto.HqOrderDetailDto">
         SELECT
         -- 가맹점 정보
                f.name                   AS franchiseName


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #157 

## ✅ 작업 사항
### 본사용 주문 상세 조회
- 배송 완료일 추가

### 가맹점용 주문 상세 조회를 구현
  - 가맹점 정보
  - 주문 정보
  - 자재 정보
  - 배송 정보 조회 가능 

## 📸 스크린샷 (선택)
<img width="899" alt="image" src="https://github.com/user-attachments/assets/0bbd9582-d0e0-448e-91a7-45e1503837c0" />
<img width="902" alt="image" src="https://github.com/user-attachments/assets/497b659e-4125-4cd7-a756-8cb96038d8f9" />


## 👩‍💻 공유 포인트 및 논의 사항
