### PR TITLE
✨ feat: 주문 목록 조회 조건 statusList 다중 필터 추가

### DIFF
--- a/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
+++ b/src/main/java/com/x1/frans/order/query/dto/OrderSearchConditionDto.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -13,7 +15,7 @@ public class OrderSearchConditionDto {
     private Long ownerId;
     private String code;
     private String product;
-    private String status;
+    private List<String> statusList;
     private String startDate;   // yyyy-MM-dd
     private String endDate;
     private int page;

--- a/src/main/resources/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/FranchiseOrderQueryMapper.xml
@@ -37,15 +37,22 @@
                  WHERE owner_id = #{ownerId}
                 )
             </if>
+
             <if test="code != null and code != ''">
                 AND o.code LIKE CONCAT('%', #{code}, '%')
             </if>
+
             <if test="product != null and product != ''">
                 AND p.name LIKE CONCAT('%', #{product}, '%')
             </if>
-            <if test="status != null and status != ''">
-                AND o.status LIKE CONCAT('%', #{status}, '%')
+
+            <if test="statusList != null and statusList.size > 0">
+                AND o.status IN
+                <foreach collection="statusList" item="s" open="(" separator="," close=")">
+                    #{s}
+                </foreach>
             </if>
+
             <if test="startDate != null and endDate != null">
                 AND DATE(o.created_at) BETWEEN #{startDate} AND #{endDate}
             </if>
@@ -70,15 +77,22 @@
                  WHERE owner_id = #{ownerId}
                 )
             </if>
+
             <if test="code != null and code != ''">
                 AND o.code LIKE CONCAT('%', #{code}, '%')
             </if>
+
             <if test="product != null and product != ''">
                 AND p.name LIKE CONCAT('%', #{product}, '%')
             </if>
-            <if test="status != null and status != ''">
-                AND o.status LIKE CONCAT('%', #{status}, '%')
+
+            <if test="statusList != null and statusList.size > 0">
+                AND o.status IN
+                <foreach collection="statusList" item="s" open="(" separator="," close=")">
+                    #{s}
+                </foreach>
             </if>
+
             <if test="startDate != null and endDate != null">
                 AND DATE(o.created_at) BETWEEN #{startDate} AND #{endDate}
             </if>

--- a/src/main/resources/com/x1/frans/order/query/dao/HqOrderQueryMapper.xml
+++ b/src/main/resources/com/x1/frans/order/query/dao/HqOrderQueryMapper.xml
@@ -39,8 +39,11 @@
             <!-- 접수 대기, 접수 취소 상태는 볼 수 없음 -->
             o.status NOT IN ('WAITING_FOR_RECEIPT', 'RECEIPT_CANCELED')
 
-            <if test="status != null and status.trim() != ''">
-                AND o.status = #{status}
+            <if test="statusList != null and statusList.size > 0">
+                AND o.status IN
+                <foreach collection="statusList" item="s" open="(" separator="," close=")">
+                    #{s}
+                </foreach>
             </if>
 
             <if test="userId != null">
@@ -84,8 +87,11 @@
             <!-- 접수 대기, 접수 취소 상태는 볼 수 없음 -->
             o.status NOT IN ('WAITING_FOR_RECEIPT', 'RECEIPT_CANCELED')
 
-            <if test="status != null and status.trim() != ''">
-                AND o.status = #{status}
+            <if test="statusList != null and statusList.size > 0">
+                AND o.status IN
+                <foreach collection="statusList" item="s" open="(" separator="," close=")">
+                    #{s}
+                </foreach>
             </if>
 
             <if test="userId != null">


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #이슈번호

## ✅ 작업 사항
- 프론트에서 주문 상태를 다중 선택하여 필터링할 수 있도록 하기 위해 기존 단일 status List<String>로 확장.
- OrderSearchConditionDto에 statusList 필드 추가

<br>
- 다중 상태 필터링 동작 확인
  - /api/hq/orders?statusList=REVIEWING&statusList=REVIEW_COMPLETED&statusList=APPROVED&statusList=DELIVERING&page=1&size=10


## 📸 스크린샷 (선택)
<br>

## 👩‍💻 공유 포인트 및 논의 사항
- 프론트에서도 검색창 없이 드롭다운 고정 선택 방식으로 변경 예정